### PR TITLE
Finalize donation progress accounting, donor ledger, and receipts

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -18,8 +18,6 @@ Example:
 - [ ] Add need-state guard across onboarding to block revisits/edits after submission (`impact: high`, `effort: M`)
 - [ ] Add Profile "View Need" button + dedicated need review page (read-only first), then expand with secure reviewer/individual communications and supplemental document uploads (`impact: high`, `effort: L`, `revisit: after profile MVP hardening`)
 - [ ] Add reusable breadcrumb component with proper breadcrumb builder for site-wide propagation (`impact: med`, `effort: M`, `revisit: after nav/layout consolidation`)
-- [ ] Ensure raised amount/progress accounting is driven by finalized donation intents (and optionally project to need totals) (`impact: high`, `effort: M`, `revisit: after Stripe webhook MVP stabilization`)
-- [ ] Add donor donation ledger/history view with status timeline in profile (`impact: med`, `effort: M`, `revisit: after donation intent lifecycle hardening`)
 - [ ] Add webhook resilience pass: handle reconciliation signals, retries, and backfill job for missed events (`impact: high`, `effort: L`, `revisit: before production launch`)
 - [ ] Improve post-donation trust UX with finalized-intent confirmation/receipt details (not redirect-only) (`impact: med`, `effort: M`, `revisit: after ledger MVP`)
 - [ ] Implement working `Categories` navbar item + backed categories page route/render (data-driven cards/counts, desktop + mobile parity) (`impact: high`, `effort: M`, `revisit: align to docs/images/Categories - List.png + docs/images/Categories - HoverState.png + docs/images/Category - AssociatedNeeds.png + docs/images/Categories - BrowseCTA.png`)
@@ -88,5 +86,7 @@ Example:
 
 ## Done (Optional)
 - Move completed items here with date if you want historical context.
+- [x] Ensure raised amount/progress accounting is driven by finalized donation intents (and optionally project to need totals) (`impact: high`, `effort: M`, `revisit: after Stripe webhook MVP stabilization`) — 2026-03-03
+- [x] Add donor donation ledger/history view with status timeline in profile (`impact: med`, `effort: M`, `revisit: after donation intent lifecycle hardening`) — 2026-03-03
 - [x] Persist donor preferences to DB and prefill onboarding form (`impact: med`, `effort: M`, `revisit: after need flow polish`) — 2026-03-03
 - [x] Add donor onboarding completion confirmation page (`impact: low`, `effort: S`) — 2026-03-03

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/aws/smithy-go v1.24.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
+	github.com/go-pdf/fpdf v0.9.0 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.10
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.2
+	github.com/aws/smithy-go v1.24.1
 	github.com/georgysavva/scany/v2 v2.1.4
+	github.com/go-pdf/fpdf v0.9.0
 	github.com/go-playground/form/v4 v4.3.0
 	github.com/gorilla/securecookie v1.1.2
 	github.com/jackc/pgx/v5 v5.7.6
@@ -40,10 +42,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.7 // indirect
-	github.com/aws/smithy-go v1.24.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
-	github.com/go-pdf/fpdf v0.9.0 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/georgysavva/scany/v2 v2.1.4 h1:nrzHEJ4oQVRoiKmocRqA1IyGOmM/GQOEsg9UjMR5Ip4=
 github.com/georgysavva/scany/v2 v2.1.4/go.mod h1:fqp9yHZzM/PFVa3/rYEC57VmDx+KDch0LoqrJzkvtos=
+github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
+github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/form/v4 v4.3.0 h1:OVttojbQv2WNCs4P+VnjPtrt/+30Ipw4890W3OaFlvk=

--- a/internal/server/donate.go
+++ b/internal/server/donate.go
@@ -280,6 +280,10 @@ func (s *Service) loadNeedDonateSummary(ctx context.Context, needID string) (*ty
 		return nil, "", "", err
 	}
 
+	if err := s.applyFinalizedRaisedAmount(ctx, need); err != nil {
+		return nil, "", "", err
+	}
+
 	ownerName := "Anonymous"
 	user, err := s.userRepo.User(ctx, need.UserID)
 	if err == nil {

--- a/internal/server/donation_progress.go
+++ b/internal/server/donation_progress.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+
+	"christjesus/pkg/types"
+)
+
+func (s *Service) applyFinalizedRaisedAmount(ctx context.Context, need *types.Need) error {
+	if need == nil {
+		return nil
+	}
+
+	amountRaisedCents, err := s.donationIntentRepo.FinalizedAmountByNeedID(ctx, need.ID)
+	if err != nil {
+		return err
+	}
+
+	need.AmountRaisedCents = amountRaisedCents
+	return nil
+}
+
+func (s *Service) applyFinalizedRaisedAmounts(ctx context.Context, needs []*types.Need) error {
+	if len(needs) == 0 {
+		return nil
+	}
+
+	needIDs := make([]string, 0, len(needs))
+	for _, need := range needs {
+		if need == nil || need.ID == "" {
+			continue
+		}
+		needIDs = append(needIDs, need.ID)
+	}
+	if len(needIDs) == 0 {
+		return nil
+	}
+
+	amountsByNeedID, err := s.donationIntentRepo.FinalizedAmountsByNeedIDs(ctx, needIDs)
+	if err != nil {
+		return err
+	}
+
+	for _, need := range needs {
+		if need == nil || need.ID == "" {
+			continue
+		}
+		need.AmountRaisedCents = amountsByNeedID[need.ID]
+	}
+
+	return nil
+}
+
+func fundingPercentFromCents(amountRaisedCents, amountNeededCents int) int {
+	if amountNeededCents <= 0 {
+		return 0
+	}
+
+	fundingPercent := (amountRaisedCents * 100) / amountNeededCents
+	if fundingPercent < 0 {
+		fundingPercent = 0
+	}
+	if fundingPercent > 100 {
+		fundingPercent = 100
+	}
+	return fundingPercent
+}

--- a/internal/server/pages.go
+++ b/internal/server/pages.go
@@ -169,6 +169,10 @@ func (s *Service) buildBrowseResultsPageData(ctx context.Context, filters types.
 		return nil, err
 	}
 
+	if err := s.applyFinalizedRaisedAmounts(ctx, needs); err != nil {
+		return nil, err
+	}
+
 	categories, err := s.categoryRepo.Categories(ctx)
 	if err != nil {
 		return nil, err
@@ -340,16 +344,7 @@ func (s *Service) buildBrowseResultsPageData(ctx context.Context, filters types.
 			verificationLabel = "Personally Verified"
 		}
 
-		fundingPercent := 0
-		if need.AmountNeededCents > 0 {
-			fundingPercent = (need.AmountRaisedCents * 100) / need.AmountNeededCents
-			if fundingPercent < 0 {
-				fundingPercent = 0
-			}
-			if fundingPercent > 100 {
-				fundingPercent = 100
-			}
-		}
+		fundingPercent := fundingPercentFromCents(need.AmountRaisedCents, need.AmountNeededCents)
 
 		card := &types.BrowseNeedCard{
 			ID:                need.ID,
@@ -520,6 +515,12 @@ func (s *Service) handleNeedDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := s.applyFinalizedRaisedAmount(ctx, need); err != nil {
+		s.logger.WithError(err).WithField("need_id", needID).Error("failed to load finalized donation totals for need detail")
+		s.internalServerError(w)
+		return
+	}
+
 	ownerName := "Anonymous"
 	user, err := s.userRepo.User(ctx, need.UserID)
 	if err == nil {
@@ -614,16 +615,7 @@ func (s *Service) handleNeedDetail(w http.ResponseWriter, r *http.Request) {
 
 	urgencyLabel, urgencyDotClass := browseUrgency(need.Status, need.AmountNeededCents, need.AmountRaisedCents)
 
-	fundingPercent := 0
-	if need.AmountNeededCents > 0 {
-		fundingPercent = (need.AmountRaisedCents * 100) / need.AmountNeededCents
-		if fundingPercent < 0 {
-			fundingPercent = 0
-		}
-		if fundingPercent > 100 {
-			fundingPercent = 100
-		}
-	}
+	fundingPercent := fundingPercentFromCents(need.AmountRaisedCents, need.AmountNeededCents)
 
 	docs, err := s.documentRepo.DocumentsByNeedID(ctx, needID)
 	if err != nil {

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -102,25 +102,54 @@ func (s *Service) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		needLabelByID := make(map[string]string)
+		distinctNeedIDs := make([]string, 0, len(intents))
+		seenNeedIDs := make(map[string]bool)
+		for _, intent := range intents {
+			if intent == nil {
+				continue
+			}
+			needID := strings.TrimSpace(intent.NeedID)
+			if needID == "" || seenNeedIDs[needID] {
+				continue
+			}
+			seenNeedIDs[needID] = true
+			distinctNeedIDs = append(distinctNeedIDs, needID)
+		}
+
+		needLabelByID := make(map[string]string, len(distinctNeedIDs))
+		needsByID := make(map[string]*types.Need)
+		needs, err := s.needsRepo.NeedsByIDs(ctx, distinctNeedIDs)
+		if err != nil {
+			s.logger.WithError(err).WithField("user_id", userID).Error("failed to batch fetch needs for donor profile")
+			s.internalServerError(w)
+			return
+		}
+		for _, need := range needs {
+			if need == nil {
+				continue
+			}
+			needsByID[need.ID] = need
+		}
+		for _, needID := range distinctNeedIDs {
+			needLabel := "Need request"
+			if need, ok := needsByID[needID]; ok {
+				shortDescription := strings.TrimSpace(derefString(need.ShortDescription))
+				if shortDescription != "" {
+					needLabel = shortDescription
+				}
+			}
+			needLabelByID[needID] = needLabel
+		}
+
 		for _, intent := range intents {
 			if intent == nil {
 				continue
 			}
 
 			needID := strings.TrimSpace(intent.NeedID)
-			needLabel := "Need request"
-			if cached, ok := needLabelByID[needID]; ok {
-				needLabel = cached
-			} else {
-				need, err := s.needsRepo.Need(ctx, needID)
-				if err == nil && need != nil {
-					shortDescription := strings.TrimSpace(derefString(need.ShortDescription))
-					if shortDescription != "" {
-						needLabel = shortDescription
-					}
-				}
-				needLabelByID[needID] = needLabel
+			needLabel := needLabelByID[needID]
+			if strings.TrimSpace(needLabel) == "" {
+				needLabel = "Need request"
 			}
 
 			donationSummaries = append(donationSummaries, types.ProfileDonationSummary{

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -42,6 +42,7 @@ func (s *Service) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 
 	myNeeds := make([]*types.Need, 0)
 	needSummaries := make([]types.ProfileNeedSummary, 0)
+	donationSummaries := make([]types.ProfileDonationSummary, 0)
 	if userType == string(types.UserTypeNeed) {
 		needs, err := s.needsRepo.NeedsByUser(ctx, userID)
 		if err != nil {
@@ -93,22 +94,61 @@ func (s *Service) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	donatedNeeds := make([]*types.Need, 0)
+	if userType == string(types.UserTypeDonor) {
+		intents, err := s.donationIntentRepo.DonationIntentsByDonorUserID(ctx, userID)
+		if err != nil {
+			s.logger.WithError(err).WithField("user_id", userID).Error("failed to fetch donation intents for profile")
+			s.internalServerError(w)
+			return
+		}
+
+		needLabelByID := make(map[string]string)
+		for _, intent := range intents {
+			if intent == nil {
+				continue
+			}
+
+			needID := strings.TrimSpace(intent.NeedID)
+			needLabel := "Need request"
+			if cached, ok := needLabelByID[needID]; ok {
+				needLabel = cached
+			} else {
+				need, err := s.needsRepo.Need(ctx, needID)
+				if err == nil && need != nil {
+					shortDescription := strings.TrimSpace(derefString(need.ShortDescription))
+					if shortDescription != "" {
+						needLabel = shortDescription
+					}
+				}
+				needLabelByID[needID] = needLabel
+			}
+
+			donationSummaries = append(donationSummaries, types.ProfileDonationSummary{
+				IntentID:    intent.ID,
+				NeedID:      needID,
+				NeedLabel:   needLabel,
+				Amount:      formatUSDFromCents(intent.AmountCents),
+				Status:      formatDonationStatus(intent.PaymentStatus),
+				IsAnonymous: intent.IsAnonymous,
+				CreatedAt:   intent.CreatedAt.Format("Jan 2, 2006"),
+			})
+		}
+	}
 
 	data := &types.ProfilePageData{
-		BasePageData:   types.BasePageData{Title: "My Profile"},
-		UserID:         userID,
-		UserEmail:      userEmail,
-		WelcomeName:    userName,
-		UserType:       userType,
-		Notice:         strings.TrimSpace(r.URL.Query().Get("notice")),
-		Error:          strings.TrimSpace(r.URL.Query().Get("error")),
-		SidebarItems:   buildProfileSidebar(userType),
-		Needs:          myNeeds,
-		NeedSummaries:  needSummaries,
-		DonatedNeeds:   donatedNeeds,
-		HasNeeds:       len(myNeeds) > 0,
-		HasDonatedNeed: len(donatedNeeds) > 0,
+		BasePageData:      types.BasePageData{Title: "My Profile"},
+		UserID:            userID,
+		UserEmail:         userEmail,
+		WelcomeName:       userName,
+		UserType:          userType,
+		Notice:            strings.TrimSpace(r.URL.Query().Get("notice")),
+		Error:             strings.TrimSpace(r.URL.Query().Get("error")),
+		SidebarItems:      buildProfileSidebar(userType),
+		Needs:             myNeeds,
+		NeedSummaries:     needSummaries,
+		DonationSummaries: donationSummaries,
+		HasNeeds:          len(myNeeds) > 0,
+		HasDonations:      len(donationSummaries) > 0,
 	}
 
 	err = s.renderTemplate(w, r, "page.profile", data)
@@ -227,6 +267,21 @@ func formatNeedStepLabel(step types.NeedStep) string {
 		return "Review"
 	case types.NeedStepComplete:
 		return "Complete"
+	default:
+		return "Unknown"
+	}
+}
+
+func formatDonationStatus(status string) string {
+	switch strings.TrimSpace(strings.ToLower(status)) {
+	case types.DonationPaymentStatusFinalized:
+		return "Finalized"
+	case types.DonationPaymentStatusPending:
+		return "Pending"
+	case types.DonationPaymentStatusFailed:
+		return "Failed"
+	case types.DonationPaymentStatusCanceled:
+		return "Canceled"
 	default:
 		return "Unknown"
 	}

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -324,7 +324,7 @@ func buildProfileSidebar(userType string) []types.ProfileNavItem {
 		{Label: "Profile Overview", Href: "#overview", Active: true, Section: "overview", ShowItem: true},
 		{Label: "My Needs", Href: "#my-needs", Active: false, Section: "my-needs", ShowItem: userType == string(types.UserTypeNeed)},
 		{Label: "Need Status", Href: "#need-status", Active: false, Section: "need-status", ShowItem: userType == string(types.UserTypeNeed)},
-		{Label: "Needs I've Donated To", Href: "#donations", Active: false, Section: "donations", ShowItem: userType == string(types.UserTypeDonor)},
+		{Label: "Donation History", Href: "#donations", Active: false, Section: "donations", ShowItem: userType == string(types.UserTypeDonor)},
 	}
 
 	filtered := make([]types.ProfileNavItem, 0, len(items))

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -152,12 +152,15 @@ func (s *Service) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 				needLabel = "Need request"
 			}
 
+			isFinalized := strings.TrimSpace(strings.ToLower(intent.PaymentStatus)) == types.DonationPaymentStatusFinalized
+
 			donationSummaries = append(donationSummaries, types.ProfileDonationSummary{
 				IntentID:    intent.ID,
 				NeedID:      needID,
 				NeedLabel:   needLabel,
 				Amount:      formatUSDFromCents(intent.AmountCents),
 				Status:      formatDonationStatus(intent.PaymentStatus),
+				IsFinalized: isFinalized,
 				IsAnonymous: intent.IsAnonymous,
 				CreatedAt:   intent.CreatedAt.Format("Jan 2, 2006"),
 			})

--- a/internal/server/profile_receipt.go
+++ b/internal/server/profile_receipt.go
@@ -49,9 +49,13 @@ func (s *Service) handleGetProfileDonationReceipt(w http.ResponseWriter, r *http
 	}
 
 	need, err := s.needsRepo.Need(ctx, intent.NeedID)
-	if err != nil {
+	if err != nil && !errors.Is(err, types.ErrNeedNotFound) {
 		s.logger.WithError(err).WithField("need_id", intent.NeedID).Error("failed to fetch need for donation receipt")
 		s.internalServerError(w)
+		return
+	}
+	if errors.Is(err, types.ErrNeedNotFound) {
+		s.redirectProfileWithError(w, r, "Need not found for this donation receipt.")
 		return
 	}
 

--- a/internal/server/profile_receipt.go
+++ b/internal/server/profile_receipt.go
@@ -1,0 +1,196 @@
+package server
+
+import (
+	"bytes"
+	"christjesus/pkg/types"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+	"github.com/go-pdf/fpdf"
+)
+
+func (s *Service) handleGetProfileDonationReceipt(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userID, err := s.userIDFromContext(ctx)
+	if err != nil {
+		s.logger.WithError(err).Error("user id not found in context")
+		s.internalServerError(w)
+		return
+	}
+
+	intentID := strings.TrimSpace(r.PathValue("intentID"))
+	if intentID == "" {
+		s.redirectProfileWithError(w, r, "Donation not found.")
+		return
+	}
+
+	intent, err := s.donationIntentRepo.ByID(ctx, intentID)
+	if err != nil {
+		s.logger.WithError(err).WithField("intent_id", intentID).Error("failed to fetch donation intent for receipt")
+		s.internalServerError(w)
+		return
+	}
+	if intent == nil || intent.DonorUserID == nil || strings.TrimSpace(*intent.DonorUserID) != userID {
+		s.redirectProfileWithError(w, r, "Donation not found.")
+		return
+	}
+
+	if strings.TrimSpace(strings.ToLower(intent.PaymentStatus)) != types.DonationPaymentStatusFinalized {
+		s.redirectProfileWithError(w, r, "Receipt is available after payment is finalized.")
+		return
+	}
+
+	need, err := s.needsRepo.Need(ctx, intent.NeedID)
+	if err != nil {
+		s.logger.WithError(err).WithField("need_id", intent.NeedID).Error("failed to fetch need for donation receipt")
+		s.internalServerError(w)
+		return
+	}
+
+	userEmail, _ := ctx.Value(contextKeyEmail).(string)
+	userName, _ := ctx.Value(contextKeyUserName).(string)
+	if strings.TrimSpace(userName) == "" {
+		userName = displayNameFromEmail(userEmail)
+	}
+
+	needLabel := strings.TrimSpace(derefString(need.ShortDescription))
+	if needLabel == "" {
+		needLabel = "Need request"
+	}
+
+	receiptKey := fmt.Sprintf("receipts/donations/%s.pdf", intent.ID)
+	filename := fmt.Sprintf("christjesus-receipt-%s.pdf", intent.ID)
+
+	cachedReceipt, err := s.s3Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.config.S3BucketName),
+		Key:    aws.String(receiptKey),
+	})
+	if err == nil {
+		defer cachedReceipt.Body.Close()
+		w.Header().Set("Content-Type", "application/pdf")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", filename))
+		w.Header().Set("Cache-Control", "private, no-store")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, cachedReceipt.Body)
+		return
+	}
+
+	if !isS3NotFoundError(err) {
+		s.logger.WithError(err).WithField("intent_id", intent.ID).Error("failed to load cached donation receipt from s3")
+		s.internalServerError(w)
+		return
+	}
+
+	pdfBytes, err := buildDonationReceiptPDF(types.ProfileDonationSummary{
+		IntentID:    intent.ID,
+		NeedID:      intent.NeedID,
+		NeedLabel:   needLabel,
+		Amount:      formatUSDFromCents(intent.AmountCents),
+		Status:      formatDonationStatus(intent.PaymentStatus),
+		IsAnonymous: intent.IsAnonymous,
+		CreatedAt:   intent.CreatedAt.Format("Jan 2, 2006 3:04 PM MST"),
+	}, userName, userEmail, s.config.AppBaseURL)
+	if err != nil {
+		s.logger.WithError(err).WithField("intent_id", intent.ID).Error("failed to generate donation receipt pdf")
+		s.internalServerError(w)
+		return
+	}
+
+	_, err = s.s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.config.S3BucketName),
+		Key:         aws.String(receiptKey),
+		Body:        bytes.NewReader(pdfBytes),
+		ContentType: aws.String("application/pdf"),
+	})
+	if err != nil {
+		s.logger.WithError(err).WithField("intent_id", intent.ID).Error("failed to store donation receipt pdf in s3")
+		s.internalServerError(w)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/pdf")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", filename))
+	w.Header().Set("Cache-Control", "private, no-store")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(pdfBytes)
+}
+
+func buildDonationReceiptPDF(summary types.ProfileDonationSummary, donorName, donorEmail, appBaseURL string) ([]byte, error) {
+	pdf := fpdf.New("P", "mm", "Letter", "")
+	pdf.SetAutoPageBreak(true, 12)
+	pdf.SetTitle("ChristJesus Donation Receipt "+summary.IntentID, false)
+	pdf.SetAuthor("ChristJesus", false)
+	pdf.SetSubject("Donation receipt", false)
+	pdf.AddPage()
+
+	pdf.SetFont("Helvetica", "B", 18)
+	pdf.CellFormat(0, 12, "Donation Receipt", "", 1, "L", false, 0, "")
+
+	pdf.SetFont("Helvetica", "", 11)
+	pdf.SetTextColor(70, 70, 70)
+	pdf.CellFormat(0, 7, "ChristJesus", "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Generated: "+time.Now().Format("Jan 2, 2006 3:04 PM MST"), "", 1, "L", false, 0, "")
+	pdf.Ln(2)
+
+	pdf.SetTextColor(20, 20, 20)
+	pdf.SetFont("Helvetica", "B", 12)
+	pdf.CellFormat(0, 8, "Receipt Details", "", 1, "L", false, 0, "")
+	pdf.SetFont("Helvetica", "", 11)
+	pdf.CellFormat(0, 7, "Receipt ID: "+summary.IntentID, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Donation Date: "+summary.CreatedAt, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Amount: "+summary.Amount, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Status: "+summary.Status, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Anonymous Donation: "+map[bool]string{true: "Yes", false: "No"}[summary.IsAnonymous], "", 1, "L", false, 0, "")
+	pdf.Ln(2)
+
+	pdf.SetFont("Helvetica", "B", 12)
+	pdf.CellFormat(0, 8, "Need", "", 1, "L", false, 0, "")
+	pdf.SetFont("Helvetica", "", 11)
+	pdf.MultiCell(0, 7, summary.NeedLabel, "", "L", false)
+	needURL := strings.TrimRight(strings.TrimSpace(appBaseURL), "/") + "/need/" + summary.NeedID
+	if strings.TrimSpace(appBaseURL) == "" {
+		needURL = "/need/" + summary.NeedID
+	}
+	pdf.SetTextColor(20, 20, 20)
+	pdf.CellFormat(22, 7, "Need Link:", "", 0, "L", false, 0, "")
+	pdf.SetTextColor(37, 99, 235)
+	pdf.CellFormat(0, 7, "View need", "", 1, "L", false, 0, needURL)
+	pdf.SetTextColor(20, 20, 20)
+	pdf.Ln(2)
+
+	pdf.SetFont("Helvetica", "B", 12)
+	pdf.CellFormat(0, 8, "Donor", "", 1, "L", false, 0, "")
+	pdf.SetFont("Helvetica", "", 11)
+	pdf.CellFormat(0, 7, "Name: "+strings.TrimSpace(donorName), "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Email: "+strings.TrimSpace(donorEmail), "", 1, "L", false, 0, "")
+	pdf.Ln(4)
+
+	pdf.SetTextColor(90, 90, 90)
+	pdf.SetFont("Helvetica", "", 9)
+	pdf.MultiCell(0, 5, "This document is a donation receipt generated by ChristJesus from payment records. Keep this receipt for your records.", "", "L", false)
+
+	var output bytes.Buffer
+	if err := pdf.Output(&output); err != nil {
+		return nil, err
+	}
+
+	return output.Bytes(), nil
+}
+
+func isS3NotFoundError(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	code := strings.TrimSpace(apiErr.ErrorCode())
+	return code == "NoSuchKey" || code == "NotFound"
+}

--- a/internal/server/profile_receipt.go
+++ b/internal/server/profile_receipt.go
@@ -83,7 +83,9 @@ func (s *Service) handleGetProfileDonationReceipt(w http.ResponseWriter, r *http
 		w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", filename))
 		w.Header().Set("Cache-Control", "private, no-store")
 		w.WriteHeader(http.StatusOK)
-		_, _ = io.Copy(w, cachedReceipt.Body)
+		if _, err := io.Copy(w, cachedReceipt.Body); err != nil {
+			s.logger.WithError(err).WithField("intent_id", intent.ID).Error("failed to stream cached donation receipt pdf")
+		}
 		return
 	}
 
@@ -124,13 +126,24 @@ func (s *Service) handleGetProfileDonationReceipt(w http.ResponseWriter, r *http
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", filename))
 	w.Header().Set("Cache-Control", "private, no-store")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(pdfBytes)
+	if _, err := w.Write(pdfBytes); err != nil {
+		s.logger.WithError(err).WithField("intent_id", intent.ID).Error("failed to write donation receipt pdf response")
+		return
+	}
 }
 
 func buildDonationReceiptPDF(summary types.ProfileDonationSummary, donorName, donorEmail, appBaseURL string) ([]byte, error) {
+	safeIntentID := pdfSafeText(summary.IntentID)
+	safeCreatedAt := pdfSafeText(summary.CreatedAt)
+	safeAmount := pdfSafeText(summary.Amount)
+	safeStatus := pdfSafeText(summary.Status)
+	safeNeedLabel := pdfSafeText(summary.NeedLabel)
+	safeDonorName := pdfSafeText(donorName)
+	safeDonorEmail := pdfSafeText(donorEmail)
+
 	pdf := fpdf.New("P", "mm", "Letter", "")
 	pdf.SetAutoPageBreak(true, 12)
-	pdf.SetTitle("ChristJesus Donation Receipt "+summary.IntentID, false)
+	pdf.SetTitle("ChristJesus Donation Receipt "+safeIntentID, false)
 	pdf.SetAuthor("ChristJesus", false)
 	pdf.SetSubject("Donation receipt", false)
 	pdf.AddPage()
@@ -148,17 +161,17 @@ func buildDonationReceiptPDF(summary types.ProfileDonationSummary, donorName, do
 	pdf.SetFont("Helvetica", "B", 12)
 	pdf.CellFormat(0, 8, "Receipt Details", "", 1, "L", false, 0, "")
 	pdf.SetFont("Helvetica", "", 11)
-	pdf.CellFormat(0, 7, "Receipt ID: "+summary.IntentID, "", 1, "L", false, 0, "")
-	pdf.CellFormat(0, 7, "Donation Date: "+summary.CreatedAt, "", 1, "L", false, 0, "")
-	pdf.CellFormat(0, 7, "Amount: "+summary.Amount, "", 1, "L", false, 0, "")
-	pdf.CellFormat(0, 7, "Status: "+summary.Status, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Receipt ID: "+safeIntentID, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Donation Date: "+safeCreatedAt, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Amount: "+safeAmount, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Status: "+safeStatus, "", 1, "L", false, 0, "")
 	pdf.CellFormat(0, 7, "Anonymous Donation: "+map[bool]string{true: "Yes", false: "No"}[summary.IsAnonymous], "", 1, "L", false, 0, "")
 	pdf.Ln(2)
 
 	pdf.SetFont("Helvetica", "B", 12)
 	pdf.CellFormat(0, 8, "Need", "", 1, "L", false, 0, "")
 	pdf.SetFont("Helvetica", "", 11)
-	pdf.MultiCell(0, 7, summary.NeedLabel, "", "L", false)
+	pdf.MultiCell(0, 7, safeNeedLabel, "", "L", false)
 	needURL := strings.TrimRight(strings.TrimSpace(appBaseURL), "/") + "/need/" + summary.NeedID
 	if strings.TrimSpace(appBaseURL) == "" {
 		needURL = "/need/" + summary.NeedID
@@ -173,8 +186,8 @@ func buildDonationReceiptPDF(summary types.ProfileDonationSummary, donorName, do
 	pdf.SetFont("Helvetica", "B", 12)
 	pdf.CellFormat(0, 8, "Donor", "", 1, "L", false, 0, "")
 	pdf.SetFont("Helvetica", "", 11)
-	pdf.CellFormat(0, 7, "Name: "+strings.TrimSpace(donorName), "", 1, "L", false, 0, "")
-	pdf.CellFormat(0, 7, "Email: "+strings.TrimSpace(donorEmail), "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Name: "+safeDonorName, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 7, "Email: "+safeDonorEmail, "", 1, "L", false, 0, "")
 	pdf.Ln(4)
 
 	pdf.SetTextColor(90, 90, 90)
@@ -187,6 +200,24 @@ func buildDonationReceiptPDF(summary types.ProfileDonationSummary, donorName, do
 	}
 
 	return output.Bytes(), nil
+}
+
+func pdfSafeText(value string) string {
+	clean := strings.ToValidUTF8(value, "")
+	var b strings.Builder
+	b.Grow(len(clean))
+	for _, r := range clean {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteRune(r)
+		case r >= 32 && r <= 255:
+			b.WriteRune(r)
+		default:
+			b.WriteRune('?')
+		}
+	}
+
+	return strings.TrimSpace(b.String())
 }
 
 func isS3NotFoundError(err error) bool {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -158,6 +158,7 @@ func (s *Service) buildRouter(r *flow.Mux) {
 
 		r.HandleFunc("/profile", s.handleGetProfile, http.MethodGet)
 		r.HandleFunc("/profile/needs/:needID/delete", s.handlePostProfileNeedDelete, http.MethodPost)
+		r.HandleFunc("/profile/donations/:intentID/receipt", s.handleGetProfileDonationReceipt, http.MethodGet)
 
 		r.HandleFunc("/onboarding", s.handleGetOnboarding, http.MethodGet)
 		r.HandleFunc("/onboarding", s.handlePostOnboarding, http.MethodPost)

--- a/internal/server/templates/pages/profile.html
+++ b/internal/server/templates/pages/profile.html
@@ -85,18 +85,43 @@
 
       {{if eq .UserType "donor"}}
       <div id="donations" class="rounded-xl border bg-background p-6">
-        <h2 class="text-xl font-semibold text-foreground">Needs I’ve Donated To</h2>
-        {{if .HasDonatedNeed}}
-        <ul class="mt-4 space-y-3">
-          {{range .DonatedNeeds}}
-          <li class="rounded-lg border p-4">
-            <p class="text-sm font-semibold text-foreground">Need ID: {{.ID}}</p>
-            <p class="mt-1 text-sm text-muted-foreground">Status: {{.Status}}</p>
-          </li>
-          {{end}}
-        </ul>
+        <h2 class="text-xl font-semibold text-foreground">Donation History</h2>
+        {{if .HasDonations}}
+        <div class="mt-4 overflow-x-auto rounded-lg border">
+          <table class="w-full min-w-[700px] divide-y divide-border text-left">
+            <thead class="bg-muted/50">
+              <tr>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Need</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Amount</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Status</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Anonymous</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Date</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border bg-background">
+              {{range .DonationSummaries}}
+              <tr>
+                <td class="px-4 py-3 text-sm font-medium text-foreground">{{.NeedLabel}}</td>
+                <td class="px-4 py-3 text-sm text-muted-foreground">{{.Amount}}</td>
+                <td class="px-4 py-3 text-sm text-muted-foreground">{{.Status}}</td>
+                <td class="px-4 py-3 text-sm text-muted-foreground">{{if .IsAnonymous}}Yes
+                  {{else}}No{{end}}
+                </td>
+                <td class="px-4 py-3 text-sm text-muted-foreground">{{.CreatedAt}}</td>
+                <td class="px-4 py-3 text-sm">
+                  <div class="flex items-center gap-3">
+                    <a href="/need/{{.NeedID}}" class="font-medium text-[color:var(--cj-primary)] hover:underline">View need</a>
+                    <a href="/profile/donations/{{.IntentID}}/receipt" target="_blank" rel="noopener noreferrer" class="font-medium text-[color:var(--cj-primary)] hover:underline">View receipt</a>
+                  </div>
+                </td>
+              </tr>
+              {{end}}
+            </tbody>
+          </table>
+        </div>
         {{else}}
-          <p class="mt-4 text-sm text-muted-foreground">No donated needs to show yet.</p>
+          <p class="mt-4 text-sm text-muted-foreground">No donations to show yet.</p>
           {{end}}
       </div>
       {{end}}

--- a/internal/server/templates/pages/profile.html
+++ b/internal/server/templates/pages/profile.html
@@ -112,7 +112,11 @@
                 <td class="px-4 py-3 text-sm">
                   <div class="flex items-center gap-3">
                     <a href="/need/{{.NeedID}}" class="font-medium text-[color:var(--cj-primary)] hover:underline">View need</a>
+                    {{if .IsFinalized}}
                     <a href="/profile/donations/{{.IntentID}}/receipt" target="_blank" rel="noopener noreferrer" class="font-medium text-[color:var(--cj-primary)] hover:underline">View receipt</a>
+                    {{else}}
+                      <span class="text-muted-foreground">Receipt pending</span>
+                      {{end}}
                   </div>
                 </td>
               </tr>

--- a/internal/store/donation_intent.go
+++ b/internal/store/donation_intent.go
@@ -169,3 +169,78 @@ func (r *DonationIntentRepository) MarkIntentFailedByID(ctx context.Context, int
 
 	return tag.RowsAffected() > 0, nil
 }
+
+func (r *DonationIntentRepository) FinalizedAmountByNeedID(ctx context.Context, needID string) (int, error) {
+	query, args, err := psql().
+		Select("COALESCE(SUM(amount_cents), 0)").
+		From(donationIntentTableName).
+		Where(sq.Eq{"need_id": needID, "payment_status": types.DonationPaymentStatusFinalized}).
+		ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("failed to generate finalized amount by need query: %w", err)
+	}
+
+	var amountCents int
+	if err := r.pool.QueryRow(ctx, query, args...).Scan(&amountCents); err != nil {
+		return 0, fmt.Errorf("failed to fetch finalized amount by need: %w", err)
+	}
+
+	return amountCents, nil
+}
+
+func (r *DonationIntentRepository) FinalizedAmountsByNeedIDs(ctx context.Context, needIDs []string) (map[string]int, error) {
+	amountsByNeedID := make(map[string]int)
+	if len(needIDs) == 0 {
+		return amountsByNeedID, nil
+	}
+
+	query, args, err := psql().
+		Select("need_id", "COALESCE(SUM(amount_cents), 0) AS total_amount_cents").
+		From(donationIntentTableName).
+		Where(sq.Eq{"payment_status": types.DonationPaymentStatusFinalized}).
+		Where(sq.Eq{"need_id": needIDs}).
+		GroupBy("need_id").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate finalized amounts by need ids query: %w", err)
+	}
+
+	rows := make([]struct {
+		NeedID           string `db:"need_id"`
+		TotalAmountCents int    `db:"total_amount_cents"`
+	}, 0)
+	if err := pgxscan.Select(ctx, r.pool, &rows, query, args...); err != nil {
+		if !pgxscan.NotFound(err) {
+			return nil, fmt.Errorf("failed to fetch finalized amounts by need ids: %w", err)
+		}
+	}
+
+	for _, row := range rows {
+		amountsByNeedID[row.NeedID] = row.TotalAmountCents
+	}
+
+	return amountsByNeedID, nil
+}
+
+func (r *DonationIntentRepository) DonationIntentsByDonorUserID(ctx context.Context, donorUserID string) ([]*types.DonationIntent, error) {
+	query, args, err := psql().
+		Select(donationIntentColumns...).
+		From(donationIntentTableName).
+		Where(sq.Eq{"donor_user_id": donorUserID}).
+		OrderBy("created_at desc").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate donation intents by donor user id query: %w", err)
+	}
+
+	intents := make([]*types.DonationIntent, 0)
+	err = pgxscan.Select(ctx, r.pool, &intents, query, args...)
+	if err != nil {
+		if pgxscan.NotFound(err) {
+			return intents, nil
+		}
+		return nil, fmt.Errorf("failed to fetch donation intents by donor user id: %w", err)
+	}
+
+	return intents, nil
+}

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -92,6 +92,30 @@ func (r *NeedRepository) NeedsByUser(ctx context.Context, userID string) ([]*typ
 	return needs, nil
 }
 
+func (r *NeedRepository) NeedsByIDs(ctx context.Context, needIDs []string) ([]*types.Need, error) {
+	if len(needIDs) == 0 {
+		return []*types.Need{}, nil
+	}
+
+	query, args, err := psql().Select(needColumns...).From(needTableName).
+		Where(sq.Eq{"id": needIDs}).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate needs by ids query: %w", err)
+	}
+
+	needs := make([]*types.Need, 0)
+	err = pgxscan.Select(ctx, r.pool, &needs, query, args...)
+	if err != nil {
+		if pgxscan.NotFound(err) {
+			return needs, nil
+		}
+		return nil, fmt.Errorf("failed to fetch needs by ids: %w", err)
+	}
+
+	return needs, nil
+}
+
 func (r *NeedRepository) NeedsByStatus(ctx context.Context, userID string) ([]*types.Need, error) {
 
 	query, args, err := psql().Select(needColumns...).From(needTableName).

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -252,18 +252,18 @@ type ProfileNavItem struct {
 
 type ProfilePageData struct {
 	BasePageData
-	UserID         string
-	UserEmail      string
-	WelcomeName    string
-	UserType       string
-	Notice         string
-	Error          string
-	SidebarItems   []ProfileNavItem
-	Needs          []*Need
-	NeedSummaries  []ProfileNeedSummary
-	DonatedNeeds   []*Need
-	HasNeeds       bool
-	HasDonatedNeed bool
+	UserID            string
+	UserEmail         string
+	WelcomeName       string
+	UserType          string
+	Notice            string
+	Error             string
+	SidebarItems      []ProfileNavItem
+	Needs             []*Need
+	NeedSummaries     []ProfileNeedSummary
+	DonationSummaries []ProfileDonationSummary
+	HasNeeds          bool
+	HasDonations      bool
 }
 
 type ProfileNeedSummary struct {
@@ -273,4 +273,14 @@ type ProfileNeedSummary struct {
 	CurrentStep         string
 	Status              NeedStatus
 	CanDelete           bool
+}
+
+type ProfileDonationSummary struct {
+	IntentID    string
+	NeedID      string
+	NeedLabel   string
+	Amount      string
+	Status      string
+	IsAnonymous bool
+	CreatedAt   string
 }

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -281,6 +281,7 @@ type ProfileDonationSummary struct {
 	NeedLabel   string
 	Amount      string
 	Status      string
+	IsFinalized bool
 	IsAnonymous bool
 	CreatedAt   string
 }


### PR DESCRIPTION
## Summary
- derive raised/progress amounts from finalized donation intents across browse, need detail, and donate summary views
- add donor donation ledger/history to profile with table layout and per-row actions
- add on-demand donor receipt generation and S3 caching via `/profile/donations/:intentID/receipt`
- render receipt inline in browser (new tab from ledger) with clickable "View need" link and PDF metadata title
- mark completed backlog items for finalized accounting and donor ledger

## Validation
- gofmt on changed Go files
- just test