### PR TITLE
Add categories listing and category needs pages

### DIFF
--- a/internal/server/categories.go
+++ b/internal/server/categories.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"christjesus/pkg/types"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (s *Service) handleCategories(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	categories, err := s.categoryRepo.Categories(ctx)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to fetch categories for categories page")
+		s.internalServerError(w)
+		return
+	}
+
+	categoryIDs := make([]string, 0, len(categories))
+	for _, category := range categories {
+		if category == nil || strings.TrimSpace(category.ID) == "" {
+			continue
+		}
+		categoryIDs = append(categoryIDs, category.ID)
+	}
+
+	countsByCategoryID, err := s.needCategoryAssignmentsRepo.PrimaryNeedCountsByCategoryIDs(ctx, categoryIDs)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to fetch category need counts")
+		s.internalServerError(w)
+		return
+	}
+
+	city := strings.TrimSpace(r.URL.Query().Get("city"))
+	cityQuery := ""
+	if city != "" {
+		cityQuery = "?city=" + url.QueryEscape(city)
+	}
+
+	items := make([]*types.CategoryListItem, 0, len(categories))
+	for _, category := range categories {
+		if category == nil {
+			continue
+		}
+
+		slug := strings.TrimSpace(category.Slug)
+		if slug == "" {
+			slug = slugifyCategoryName(category.Name)
+		}
+
+		items = append(items, &types.CategoryListItem{
+			ID:          category.ID,
+			Name:        category.Name,
+			Slug:        slug,
+			Description: category.Description,
+			Icon:        category.Icon,
+			NeedCount:   countsByCategoryID[category.ID],
+			Href:        "/category/" + slug + cityQuery,
+		})
+	}
+
+	browseHref := "/browse"
+	if cityQuery != "" {
+		browseHref += cityQuery
+	}
+
+	data := &types.CategoriesPageData{
+		BasePageData: types.BasePageData{Title: "Categories"},
+		Categories:   items,
+		BrowseHref:   browseHref,
+	}
+
+	if err := s.renderTemplate(w, r, "page.categories", data); err != nil {
+		s.logger.WithError(err).Error("failed to render categories page")
+		s.internalServerError(w)
+		return
+	}
+}
+
+func (s *Service) handleCategoryNeeds(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	slug := strings.TrimSpace(r.PathValue("slug"))
+	if slug == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	category, err := s.categoryRepo.CategoryBySlug(ctx, slug)
+	if err != nil {
+		s.logger.WithError(err).WithField("slug", slug).Error("failed to fetch category by slug")
+		s.internalServerError(w)
+		return
+	}
+	if category == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	filters := parseBrowseFilters(r.URL.Query())
+	filters.CategoryIDs = map[string]bool{category.ID: true}
+
+	browseData, err := s.buildBrowseResultsPageData(ctx, filters)
+	if err != nil {
+		s.logger.WithError(err).WithField("category_id", category.ID).Error("failed to build category needs results")
+		s.internalServerError(w)
+		return
+	}
+
+	city := strings.TrimSpace(r.URL.Query().Get("city"))
+	cityQuery := ""
+	if city != "" {
+		cityQuery = "?city=" + url.QueryEscape(city)
+	}
+
+	backHref := "/categories"
+	browseHref := "/browse"
+	if cityQuery != "" {
+		backHref += cityQuery
+		browseHref += cityQuery
+	}
+
+	data := &types.CategoryNeedsPageData{
+		BasePageData: types.BasePageData{Title: fmt.Sprintf("%s Needs", category.Name)},
+		Category:     category,
+		Needs:        browseData.Needs,
+		BackHref:     backHref,
+		BrowseHref:   browseHref,
+	}
+
+	if err := s.renderTemplate(w, r, "page.category.needs", data); err != nil {
+		s.logger.WithError(err).Error("failed to render category needs page")
+		s.internalServerError(w)
+		return
+	}
+}
+
+func slugifyCategoryName(name string) string {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	normalized = strings.ReplaceAll(normalized, "&", "and")
+	normalized = strings.ReplaceAll(normalized, " ", "-")
+	for strings.Contains(normalized, "--") {
+		normalized = strings.ReplaceAll(normalized, "--", "-")
+	}
+	return strings.Trim(normalized, "-")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -197,6 +197,8 @@ func (s *Service) buildRouter(r *flow.Mux) {
 	// r.HandleFunc("/onboarding/sponsor/organization/welcome", s.handleGetOnboardingSponsorOrganizationWelcome, http.MethodGet)
 
 	r.HandleFunc("/browse", s.handleBrowse, http.MethodGet)
+	r.HandleFunc("/categories", s.handleCategories, http.MethodGet)
+	r.HandleFunc("/category/:slug", s.handleCategoryNeeds, http.MethodGet)
 	r.HandleFunc("/need/:id", s.handleNeedDetail, http.MethodGet)
 	r.HandleFunc("/webhooks/stripe", s.handlePostStripeWebhook, http.MethodPost)
 	// r.HandleFunc("/forms/prayer", s.handlePrayerRequestSubmit, http.MethodPost)

--- a/internal/server/templates/pages/categories.html
+++ b/internal/server/templates/pages/categories.html
@@ -1,0 +1,52 @@
+{{define "page.categories"}}
+{{template "header" .}}
+
+<div class="mx-auto w-full max-w-6xl px-4 py-10 md:px-6">
+  <div class="space-y-2">
+    <p class="text-sm font-semibold uppercase tracking-wide text-[color:var(--cj-accent)]">Categories</p>
+    <h1 class="text-3xl font-semibold text-foreground">Explore needs by category</h1>
+    <p class="text-muted-foreground">Find verified needs aligned with your heart to serve.</p>
+  </div>
+
+  {{if .Categories}}
+  <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    {{range .Categories}}
+    <a href="{{.Href}}" class="group h-full">
+      <article class="flex h-full flex-col gap-6 rounded-xl border py-6 shadow-sm transition-all hover:-translate-y-1 hover:border-[color:var(--cj-accent)] hover:shadow-lg">
+        <div class="space-y-4 px-6">
+          <div class="flex h-11 w-11 items-center justify-center rounded-full bg-[color:var(--cj-accent)]/10 text-sm font-semibold text-[color:var(--cj-accent)] transition group-hover:bg-[color:var(--cj-accent)]/20">
+            {{if .Icon}}
+              {{.Icon}}
+            {{else}}
+              •
+            {{end}}
+          </div>
+          <div>
+            <p class="text-base font-semibold text-foreground">{{.Name}}</p>
+            <p class="text-sm text-muted-foreground">{{.NeedCount}} active needs</p>
+          </div>
+        </div>
+      </article>
+    </a>
+    {{end}}
+  </div>
+  {{else}}
+  <div class="mt-8 rounded-xl border border-border bg-card px-6 py-10 text-center text-card-foreground shadow-sm">
+    <p class="text-sm text-muted-foreground">No categories are available right now.</p>
+  </div>
+  {{end}}
+
+  <div class="mt-10 flex flex-col items-start gap-3 rounded-2xl border border-border bg-slate-50 p-6 md:flex-row md:items-center md:justify-between">
+    <div>
+      <p class="text-lg font-semibold text-foreground">Ready to browse all needs?</p>
+      <p class="text-sm text-muted-foreground">Use filters to refine by urgency, verification level, and location.</p>
+    </div>
+    <a href="{{.BrowseHref}}"
+      class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
+      Browse Needs
+    </a>
+  </div>
+</div>
+
+{{template "footer" .}}
+{{end}}

--- a/internal/server/templates/pages/category-needs.html
+++ b/internal/server/templates/pages/category-needs.html
@@ -1,0 +1,42 @@
+{{define "page.category.needs"}}
+{{template "header" .}}
+
+<div class="mx-auto w-full max-w-6xl px-4 py-10 md:px-6">
+  <div class="mb-6 text-sm text-muted-foreground">
+    <a href="/">Home</a> / <a href="{{.BackHref}}">Categories</a> / <span class="text-foreground">{{.Category.Name}}</span>
+  </div>
+
+  <div class="mb-8 overflow-hidden rounded-2xl border border-border bg-gradient-to-r from-slate-900 via-slate-800 to-slate-700 text-white">
+    <div class="flex flex-col gap-4 px-6 py-10 md:flex-row md:items-center md:justify-between">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-white/70">Category focus</p>
+        <h1 class="mt-2 text-3xl font-semibold md:text-4xl">{{.Category.Name}}</h1>
+        <p class="mt-2 text-sm text-white/80">Highlighting verified needs in this category.</p>
+      </div>
+      <div class="rounded-xl bg-white/10 px-5 py-4 text-sm text-white/80">
+        <p class="text-xs uppercase tracking-wide text-white/60">Active needs</p>
+        <p class="mt-1 text-2xl font-semibold text-white">{{len .Needs}}</p>
+      </div>
+    </div>
+  </div>
+
+  {{if .Needs}}
+  <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+    {{range .Needs}}
+    {{template "component.need.card" .}}
+    {{end}}
+  </div>
+  {{else}}
+  <div class="mt-10 flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border p-10 text-center">
+    <p class="text-sm font-semibold text-foreground">No needs posted for this category yet.</p>
+    <p class="text-sm text-muted-foreground">Browse all verified needs or check back soon.</p>
+    <a href="{{.BrowseHref}}"
+      class="inline-flex h-9 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground">
+      Browse all needs
+    </a>
+  </div>
+  {{end}}
+</div>
+
+{{template "footer" .}}
+{{end}}

--- a/internal/store/need_category_assignment.go
+++ b/internal/store/need_category_assignment.go
@@ -69,6 +69,40 @@ func (r *AssignmentRepository) GetAssignmentsByNeedIDs(ctx context.Context, need
 	return assignments, nil
 }
 
+func (r *AssignmentRepository) PrimaryNeedCountsByCategoryIDs(ctx context.Context, categoryIDs []string) (map[string]int, error) {
+	counts := make(map[string]int)
+	if len(categoryIDs) == 0 {
+		return counts, nil
+	}
+
+	query, args, err := psql().
+		Select("a.category_id", "COUNT(DISTINCT a.need_id) AS need_count").
+		From(assignmentTableName + " a").
+		Join("christjesus.needs n ON n.id = a.need_id").
+		Where(sq.Eq{"a.category_id": categoryIDs, "a.is_primary": true}).
+		Where(sq.NotEq{"n.status": types.NeedStatusDraft}).
+		GroupBy("a.category_id").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate primary need counts query: %w", err)
+	}
+
+	rows := make([]struct {
+		CategoryID string `db:"category_id"`
+		NeedCount  int    `db:"need_count"`
+	}, 0)
+	err = pgxscan.Select(ctx, r.pool, &rows, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch primary need counts by category ids: %w", err)
+	}
+
+	for _, row := range rows {
+		counts[row.CategoryID] = row.NeedCount
+	}
+
+	return counts, nil
+}
+
 // CreateAssignment creates a new category assignment
 func (r *AssignmentRepository) CreateAssignment(ctx context.Context, assignment *types.NeedCategoryAssignment) error {
 	now := time.Now()

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -75,6 +75,30 @@ type BrowseNeedCard struct {
 	CreatedAt         time.Time
 }
 
+type CategoriesPageData struct {
+	BasePageData
+	Categories []*CategoryListItem
+	BrowseHref string
+}
+
+type CategoryListItem struct {
+	ID          string
+	Name        string
+	Slug        string
+	Description *string
+	Icon        *string
+	NeedCount   int
+	Href        string
+}
+
+type CategoryNeedsPageData struct {
+	BasePageData
+	Category   *NeedCategory
+	Needs      []*BrowseNeedCard
+	BackHref   string
+	BrowseHref string
+}
+
 type NeedDetailPageData struct {
 	BasePageData
 	ID                  string


### PR DESCRIPTION
## Why
This PR introduces first-class category discovery pages so users can browse needs by category and quickly drill into relevant needs.

## What changed
- Added category page handlers and routing:
  - `GET /categories`
  - `GET /category/:slug`
- Added typed page data models for categories and category-needs views.
- Added repository aggregation for per-category primary need counts.
- Added server-rendered templates:
  - categories listing page
  - category detail page showing associated needs

## Data/query notes
- Category counts are derived from primary need-category assignments.
- Category detail page resolves category by slug and lists needs tied to that category.

## Validation
- Automated:
  - `just test`
- Manual:
  - Opened `/categories`
  - Navigated into a category and then into a need
  - Completed donor login flow
  - Completed Stripe sandbox donation flow end-to-end

## Out of scope
- Category ranking/personalization
- Additional filtering/sorting UX beyond current category drill-down
