### PR TITLE
Add webhook resilience reconciliation and backfill

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -18,7 +18,7 @@ Example:
 - [x] Add need-state guard across onboarding to block revisits/edits after submission (`impact: high`, `effort: M`) — 2026-03-05
 - [ ] Add Profile "View Need" button + dedicated need review page (read-only first), then expand with secure reviewer/individual communications and supplemental document uploads (`impact: high`, `effort: L`, `revisit: after profile MVP hardening`)
 - [ ] Add reusable breadcrumb component with proper breadcrumb builder for site-wide propagation (`impact: med`, `effort: M`, `revisit: after nav/layout consolidation`)
-- [ ] Add webhook resilience pass: handle reconciliation signals, retries, and backfill job for missed events (`impact: high`, `effort: L`, `revisit: before production launch`)
+- [x] Add webhook resilience pass: handle reconciliation signals, retries, and backfill job for missed events (`impact: high`, `effort: L`, `revisit: before production launch`) — 2026-03-05
 - [x] Improve post-donation trust UX with finalized-intent confirmation/receipt details (not redirect-only) (`impact: med`, `effort: M`, `revisit: after ledger MVP`) — 2026-03-05
 - [x] Implement working `Categories` navbar item + backed categories page route/render (data-driven cards/counts, desktop + mobile parity) (`impact: high`, `effort: M`, `revisit: align to docs/images/Categories - List.png + docs/images/Categories - HoverState.png + docs/images/Category - AssociatedNeeds.png + docs/images/Categories - BrowseCTA.png`) — 2026-03-05
 - [ ] Enrich homepage with additional detail sections/content density while preserving current design system and hierarchy (`impact: med`, `effort: M`, `revisit: scope from docs/images/Homepage - NeedCategories.png + docs/images/Homepage - FeaturedNeed.png + docs/images/Homepage - FeaturedNeedsHomepage.png and follow-up product notes`)
@@ -93,3 +93,4 @@ Example:
 - [x] Add need-state guard across onboarding to block revisits/edits after submission (`impact: high`, `effort: M`) — 2026-03-05
 - [x] Implement working `Categories` navbar item + backed categories page route/render (data-driven cards/counts, desktop + mobile parity) (`impact: high`, `effort: M`, `revisit: align to docs/images/Categories - List.png + docs/images/Categories - HoverState.png + docs/images/Category - AssociatedNeeds.png + docs/images/Categories - BrowseCTA.png`) — 2026-03-05
 - [x] Improve post-donation trust UX with finalized-intent confirmation/receipt details (not redirect-only) (`impact: med`, `effort: M`, `revisit: after ledger MVP`) — 2026-03-05
+- [x] Add webhook resilience pass: handle reconciliation signals, retries, and backfill job for missed events (`impact: high`, `effort: L`, `revisit: before production launch`) — 2026-03-05

--- a/cmd/christjesus/main.go
+++ b/cmd/christjesus/main.go
@@ -14,6 +14,7 @@ func main() {
 		Commands: []*cli.Command{
 			serveCommand,
 			seedCommand,
+			reconcileDonationsCommand,
 			nanoidCommand,
 		},
 	}

--- a/cmd/christjesus/reconcile_donations.go
+++ b/cmd/christjesus/reconcile_donations.go
@@ -50,7 +50,7 @@ func reconcileDonations(cCtx *cli.Context) error {
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.JSONFormatter{})
 
-	ctx := context.Background()
+	ctx := cCtx.Context
 
 	pool, err := db.Connect(ctx, cfg)
 	if err != nil {
@@ -206,7 +206,7 @@ func mapPaymentIntentStatusToAction(status string) (action string, reason string
 	case string(stripe.PaymentIntentStatusCanceled):
 		return "cancel", "payment_intent.canceled"
 	case string(stripe.PaymentIntentStatusRequiresPaymentMethod), string(stripe.PaymentIntentStatusRequiresAction):
-		return "fail", "payment_intent terminal failure state"
+		return "skip", fmt.Sprintf("payment intent requires customer action; non-terminal (%s)", status)
 	default:
 		return "skip", fmt.Sprintf("payment intent still non-terminal (%s)", status)
 	}

--- a/cmd/christjesus/reconcile_donations.go
+++ b/cmd/christjesus/reconcile_donations.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"christjesus/internal/db"
+	"christjesus/internal/store"
+	"christjesus/pkg/types"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stripe/stripe-go/v84"
+	"github.com/urfave/cli/v2"
+)
+
+var reconcileDonationsCommand = &cli.Command{
+	Name:  "reconcile-donations",
+	Usage: "Backfill and reconcile stale pending Stripe donation records",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "stale-minutes",
+			Value: 30,
+			Usage: "Treat pending donations older than this many minutes as stale and eligible for reconciliation",
+		},
+		&cli.IntFlag{
+			Name:  "limit",
+			Value: 200,
+			Usage: "Maximum number of stale pending donations to reconcile in one run",
+		},
+		&cli.BoolFlag{
+			Name:  "dry-run",
+			Usage: "Log intended updates without persisting status changes",
+		},
+	},
+	Action: reconcileDonations,
+}
+
+func reconcileDonations(cCtx *cli.Context) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if strings.TrimSpace(cfg.StripeSecretKey) == "" {
+		return fmt.Errorf("set STRIPE_SECRET_KEY before running reconcile-donations")
+	}
+
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.JSONFormatter{})
+
+	ctx := context.Background()
+
+	pool, err := db.Connect(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer pool.Close()
+
+	donationIntentRepo := store.NewDonationIntentRepository(pool)
+	stripeClient := stripe.NewClient(cfg.StripeSecretKey)
+
+	staleMinutes := cCtx.Int("stale-minutes")
+	if staleMinutes <= 0 {
+		staleMinutes = 30
+	}
+
+	limit := cCtx.Int("limit")
+	if limit <= 0 {
+		limit = 200
+	}
+
+	dryRun := cCtx.Bool("dry-run")
+	cutoff := time.Now().Add(-time.Duration(staleMinutes) * time.Minute)
+
+	intents, err := donationIntentRepo.PendingIntentsOlderThan(ctx, cutoff, limit)
+	if err != nil {
+		return fmt.Errorf("failed to query stale pending donations: %w", err)
+	}
+
+	logger.WithFields(logrus.Fields{
+		"stale_minutes": staleMinutes,
+		"limit":         limit,
+		"matched":       len(intents),
+		"dry_run":       dryRun,
+	}).Info("loaded stale pending donations for reconciliation")
+
+	var finalizedCount int
+	var failedCount int
+	var canceledCount int
+	var skippedCount int
+
+	for _, intent := range intents {
+		action, checkoutSessionID, paymentIntentID, reason, resolveErr := resolveDonationStatusFromStripe(ctx, stripeClient, intent)
+		if resolveErr != nil {
+			logger.WithError(resolveErr).WithField("intent_id", intent.ID).Warn("failed to resolve donation status from Stripe")
+			skippedCount++
+			continue
+		}
+
+		if action == "skip" {
+			logger.WithFields(logrus.Fields{
+				"intent_id": intent.ID,
+				"reason":    reason,
+			}).Info("skipping stale pending donation with no terminal Stripe signal")
+			skippedCount++
+			continue
+		}
+
+		if dryRun {
+			logger.WithFields(logrus.Fields{
+				"intent_id":             intent.ID,
+				"action":                action,
+				"checkout_session_id":   derefString(checkoutSessionID),
+				"payment_intent_id":     derefString(paymentIntentID),
+				"stripe_resolution":     reason,
+				"current_payment_state": intent.PaymentStatus,
+			}).Info("dry-run reconciliation decision")
+			continue
+		}
+
+		switch action {
+		case "finalize":
+			_, err = donationIntentRepo.FinalizeIntentByID(ctx, intent.ID, checkoutSessionID, paymentIntentID)
+			if err != nil {
+				logger.WithError(err).WithField("intent_id", intent.ID).Warn("failed to finalize stale pending donation")
+				skippedCount++
+				continue
+			}
+			finalizedCount++
+		case "fail":
+			_, err = donationIntentRepo.MarkIntentFailedByID(ctx, intent.ID, checkoutSessionID, paymentIntentID)
+			if err != nil {
+				logger.WithError(err).WithField("intent_id", intent.ID).Warn("failed to fail stale pending donation")
+				skippedCount++
+				continue
+			}
+			failedCount++
+		case "cancel":
+			_, err = donationIntentRepo.MarkIntentCanceledByID(ctx, intent.ID, checkoutSessionID, paymentIntentID)
+			if err != nil {
+				logger.WithError(err).WithField("intent_id", intent.ID).Warn("failed to cancel stale pending donation")
+				skippedCount++
+				continue
+			}
+			canceledCount++
+		default:
+			skippedCount++
+		}
+	}
+
+	logger.WithFields(logrus.Fields{
+		"processed":   len(intents),
+		"finalized":   finalizedCount,
+		"failed":      failedCount,
+		"canceled":    canceledCount,
+		"skipped":     skippedCount,
+		"dry_run":     dryRun,
+		"stale_until": cutoff.Format(time.RFC3339),
+	}).Info("donation reconciliation run complete")
+
+	return nil
+}
+
+func resolveDonationStatusFromStripe(ctx context.Context, stripeClient *stripe.Client, intent *types.DonationIntent) (action string, checkoutSessionID *string, paymentIntentID *string, reason string, err error) {
+	if intent == nil {
+		return "skip", nil, nil, "intent was nil", nil
+	}
+
+	if intent.PaymentIntentID != nil && strings.TrimSpace(*intent.PaymentIntentID) != "" {
+		paymentIntentIDValue := strings.TrimSpace(*intent.PaymentIntentID)
+		paymentIntent, retrieveErr := stripeClient.V1PaymentIntents.Retrieve(ctx, paymentIntentIDValue, nil)
+		if retrieveErr != nil {
+			return "skip", nil, nil, "", fmt.Errorf("retrieve stripe payment intent %s: %w", paymentIntentIDValue, retrieveErr)
+		}
+
+		action, reason = mapPaymentIntentStatusToAction(string(paymentIntent.Status))
+		return action, intent.CheckoutSessionID, &paymentIntentIDValue, reason, nil
+	}
+
+	if intent.CheckoutSessionID != nil && strings.TrimSpace(*intent.CheckoutSessionID) != "" {
+		checkoutSessionIDValue := strings.TrimSpace(*intent.CheckoutSessionID)
+		session, retrieveErr := stripeClient.V1CheckoutSessions.Retrieve(ctx, checkoutSessionIDValue, nil)
+		if retrieveErr != nil {
+			return "skip", nil, nil, "", fmt.Errorf("retrieve stripe checkout session %s: %w", checkoutSessionIDValue, retrieveErr)
+		}
+
+		checkoutSessionID = &checkoutSessionIDValue
+		if session.PaymentIntent != nil && strings.TrimSpace(session.PaymentIntent.ID) != "" {
+			paymentIntentIDValue := strings.TrimSpace(session.PaymentIntent.ID)
+			paymentIntentID = &paymentIntentIDValue
+		}
+
+		action, reason = mapCheckoutSessionToAction(session)
+		return action, checkoutSessionID, paymentIntentID, reason, nil
+	}
+
+	return "skip", nil, nil, "no stripe IDs available for reconciliation", nil
+}
+
+func mapPaymentIntentStatusToAction(status string) (action string, reason string) {
+	switch strings.TrimSpace(status) {
+	case string(stripe.PaymentIntentStatusSucceeded):
+		return "finalize", "payment_intent.succeeded"
+	case string(stripe.PaymentIntentStatusCanceled):
+		return "cancel", "payment_intent.canceled"
+	case string(stripe.PaymentIntentStatusRequiresPaymentMethod), string(stripe.PaymentIntentStatusRequiresAction):
+		return "fail", "payment_intent terminal failure state"
+	default:
+		return "skip", fmt.Sprintf("payment intent still non-terminal (%s)", status)
+	}
+}
+
+func mapCheckoutSessionToAction(session *stripe.CheckoutSession) (action string, reason string) {
+	if session == nil {
+		return "skip", "checkout session not found"
+	}
+
+	if session.PaymentStatus == stripe.CheckoutSessionPaymentStatusPaid {
+		return "finalize", "checkout session paid"
+	}
+
+	sessionStatus := strings.TrimSpace(string(session.Status))
+	if sessionStatus == string(stripe.CheckoutSessionStatusExpired) {
+		return "cancel", "checkout session expired"
+	}
+
+	return "skip", fmt.Sprintf("checkout session still non-terminal (status=%s payment_status=%s)", sessionStatus, session.PaymentStatus)
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/server/donate.go
+++ b/internal/server/donate.go
@@ -153,6 +153,12 @@ func (s *Service) handlePostNeedDonate(w http.ResponseWriter, r *http.Request) {
 		Mode:       stripe.String(string(stripe.CheckoutSessionModePayment)),
 		SuccessURL: stripe.String(successURL),
 		CancelURL:  stripe.String(cancelURL),
+		PaymentIntentData: &stripe.CheckoutSessionCreatePaymentIntentDataParams{
+			Metadata: map[string]string{
+				"donation_intent_id": intent.ID,
+				"need_id":            needID,
+			},
+		},
 		LineItems: []*stripe.CheckoutSessionCreateLineItemParams{
 			{
 				Quantity: stripe.Int64(1),

--- a/internal/server/stripe_webhook.go
+++ b/internal/server/stripe_webhook.go
@@ -65,6 +65,8 @@ func (s *Service) processStripeWebhookEvent(ctx context.Context, event stripe.Ev
 	switch string(event.Type) {
 	case "checkout.session.completed", "checkout.session.async_payment_succeeded", "checkout.session.async_payment_failed":
 		return s.processCheckoutSessionWebhookEvent(ctx, event)
+	case "payment_intent.succeeded", "payment_intent.payment_failed", "payment_intent.canceled":
+		return s.processPaymentIntentWebhookEvent(ctx, event)
 	default:
 		return nil
 	}
@@ -128,6 +130,65 @@ func (s *Service) processCheckoutSessionWebhookEvent(ctx context.Context, event 
 		_, err := s.donationIntentRepo.MarkIntentFailedByID(ctx, intentID, checkoutSessionID, paymentIntentID)
 		if err != nil {
 			return fmt.Errorf("mark donation intent failed from async failure: %w", err)
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (s *Service) processPaymentIntentWebhookEvent(ctx context.Context, event stripe.Event) error {
+	var paymentIntent stripe.PaymentIntent
+	if err := json.Unmarshal(event.Data.Raw, &paymentIntent); err != nil {
+		return fmt.Errorf("unmarshal payment intent event data: %w", err)
+	}
+
+	stripePaymentIntentID := strings.TrimSpace(paymentIntent.ID)
+	if stripePaymentIntentID == "" {
+		s.logger.WithField("stripe_event_id", event.ID).Warn("payment intent webhook missing payment intent id")
+		return nil
+	}
+
+	intentID := strings.TrimSpace(paymentIntent.Metadata["donation_intent_id"])
+	if intentID == "" {
+		intent, err := s.donationIntentRepo.ByPaymentIntentID(ctx, stripePaymentIntentID)
+		if err != nil {
+			return fmt.Errorf("find donation intent by payment intent id: %w", err)
+		}
+		if intent != nil {
+			intentID = intent.ID
+		}
+	}
+
+	if intentID == "" {
+		s.logger.WithFields(map[string]any{
+			"stripe_event_id":       event.ID,
+			"payment_intent_id":     stripePaymentIntentID,
+			"payment_intent_status": paymentIntent.Status,
+		}).Warn("payment intent webhook missing donation intent correlation")
+		return nil
+	}
+
+	paymentIntentID := stripePaymentIntentID
+	paymentIntentIDRef := &paymentIntentID
+
+	switch string(event.Type) {
+	case "payment_intent.succeeded":
+		_, err := s.donationIntentRepo.FinalizeIntentByID(ctx, intentID, nil, paymentIntentIDRef)
+		if err != nil {
+			return fmt.Errorf("finalize donation intent from payment_intent.succeeded: %w", err)
+		}
+		return nil
+	case "payment_intent.payment_failed":
+		_, err := s.donationIntentRepo.MarkIntentFailedByID(ctx, intentID, nil, paymentIntentIDRef)
+		if err != nil {
+			return fmt.Errorf("mark donation intent failed from payment_intent.payment_failed: %w", err)
+		}
+		return nil
+	case "payment_intent.canceled":
+		_, err := s.donationIntentRepo.MarkIntentCanceledByID(ctx, intentID, nil, paymentIntentIDRef)
+		if err != nil {
+			return fmt.Errorf("mark donation intent canceled from payment_intent.canceled: %w", err)
 		}
 		return nil
 	default:

--- a/internal/store/donation_intent.go
+++ b/internal/store/donation_intent.go
@@ -69,6 +69,30 @@ func (r *DonationIntentRepository) ByID(ctx context.Context, intentID string) (*
 	return &intent, nil
 }
 
+func (r *DonationIntentRepository) ByPaymentIntentID(ctx context.Context, paymentIntentID string) (*types.DonationIntent, error) {
+	query, args, err := psql().
+		Select(donationIntentColumns...).
+		From(donationIntentTableName).
+		Where(sq.Eq{"payment_intent_id": paymentIntentID}).
+		OrderBy("updated_at desc").
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate donation intent by payment intent id query: %w", err)
+	}
+
+	var intent types.DonationIntent
+	err = pgxscan.Get(ctx, r.pool, &intent, query, args...)
+	if err != nil {
+		if pgxscan.NotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to fetch donation intent by payment intent id: %w", err)
+	}
+
+	return &intent, nil
+}
+
 func (r *DonationIntentRepository) SetCheckoutSessionID(ctx context.Context, intentID, checkoutSessionID string) error {
 	now := time.Now()
 
@@ -168,6 +192,65 @@ func (r *DonationIntentRepository) MarkIntentFailedByID(ctx context.Context, int
 	}
 
 	return tag.RowsAffected() > 0, nil
+}
+
+func (r *DonationIntentRepository) MarkIntentCanceledByID(ctx context.Context, intentID string, checkoutSessionID, paymentIntentID *string) (bool, error) {
+	now := time.Now()
+
+	qb := psql().
+		Update(donationIntentTableName).
+		Set("payment_status", types.DonationPaymentStatusCanceled).
+		Set("updated_at", now).
+		Where(sq.Eq{"id": intentID}).
+		Where(sq.NotEq{"payment_status": types.DonationPaymentStatusFinalized})
+
+	if checkoutSessionID != nil && *checkoutSessionID != "" {
+		qb = qb.Set("checkout_session_id", *checkoutSessionID)
+	}
+	if paymentIntentID != nil && *paymentIntentID != "" {
+		qb = qb.Set("payment_intent_id", *paymentIntentID)
+	}
+
+	query, args, err := qb.ToSql()
+	if err != nil {
+		return false, fmt.Errorf("failed to generate cancel donation intent query: %w", err)
+	}
+
+	tag, err := r.pool.Exec(ctx, query, args...)
+	if err != nil {
+		return false, fmt.Errorf("failed to cancel donation intent: %w", err)
+	}
+
+	return tag.RowsAffected() > 0, nil
+}
+
+func (r *DonationIntentRepository) PendingIntentsOlderThan(ctx context.Context, cutoff time.Time, limit int) ([]*types.DonationIntent, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+
+	query, args, err := psql().
+		Select(donationIntentColumns...).
+		From(donationIntentTableName).
+		Where(sq.Eq{"payment_status": types.DonationPaymentStatusPending}).
+		Where(sq.Lt{"created_at": cutoff}).
+		OrderBy("created_at asc").
+		Limit(uint64(limit)).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate pending stale donation intents query: %w", err)
+	}
+
+	intents := make([]*types.DonationIntent, 0)
+	err = pgxscan.Select(ctx, r.pool, &intents, query, args...)
+	if err != nil {
+		if pgxscan.NotFound(err) {
+			return intents, nil
+		}
+		return nil, fmt.Errorf("failed to fetch pending stale donation intents: %w", err)
+	}
+
+	return intents, nil
 }
 
 func (r *DonationIntentRepository) FinalizedAmountByNeedID(ctx context.Context, needID string) (int, error) {

--- a/migrations/donation_intents.pg.hcl
+++ b/migrations/donation_intents.pg.hcl
@@ -91,4 +91,14 @@ table "donation_intents" {
     columns = [column.donor_user_id]
     where   = "donor_user_id IS NOT NULL"
   }
+
+  index "idx_donation_intents_payment_intent_updated" {
+    columns = [column.payment_intent_id, column.updated_at]
+    where   = "payment_intent_id IS NOT NULL"
+  }
+
+  index "idx_donation_intents_pending_created_at" {
+    columns = [column.created_at]
+    where   = "payment_status = 'pending'"
+  }
 }


### PR DESCRIPTION
## Why
Stripe webhook delivery can be delayed, retried, or occasionally missed, and donation status should still converge to backend truth.

## What changed
- Expanded webhook reconciliation signal handling for checkout session events and payment intent terminal events.
- Added payment-intent correlation fallback in webhook processing: prefer donation_intent_id metadata, then fallback to stored payment_intent_id.
- Added checkout PaymentIntent metadata at creation time to strengthen payment_intent event correlation.
- Added repository methods for resilience workflows:
  - ByPaymentIntentID
  - PendingIntentsOlderThan
  - MarkIntentCanceledByID
- Added CLI backfill command: reconcile-donations
  - scans stale pending donations
  - checks Stripe state via payment intent or checkout session
  - applies finalized, failed, or canceled transitions
  - supports flags: --dry-run, --stale-minutes, --limit

## Validation
- just test

## Usage
- Dry run: go run ./cmd/christjesus reconcile-donations --dry-run
- Apply changes: go run ./cmd/christjesus reconcile-donations
