### PR TITLE
feat(issue-10): enforce need state ownership handoffs

### DIFF
--- a/internal/server/admin_need_review.go
+++ b/internal/server/admin_need_review.go
@@ -232,6 +232,9 @@ func (s *Service) handleGetAdminNeedReview(w http.ResponseWriter, r *http.Reques
 		Timeline:            timeline,
 		BackHref:            s.route(RouteAdminNeeds, nil),
 		ModerateAction:      s.route(RouteAdminNeedModerate, map[string]string{"id": needID}),
+		AcceptReviewAction:  s.route(RouteAdminNeedModerate, map[string]string{"id": needID}),
+		CanAcceptReview:     need.Status == types.NeedStatusReadyForReview,
+		CanSubmitModeration: need.Status == types.NeedStatusUnderReview,
 		DeleteAction:        s.route(RouteAdminNeedDelete, map[string]string{"id": needID}),
 		RestoreAction:       s.route(RouteAdminNeedRestore, map[string]string{"id": needID}),
 		IsDeleted:           need.DeletedAt != nil,
@@ -289,22 +292,47 @@ func (s *Service) handlePostAdminNeedModerate(w http.ResponseWriter, r *http.Req
 	var notice string
 
 	switch action {
+	case "accept_review":
+		if need.Status != types.NeedStatusReadyForReview {
+			s.redirectAdminNeedReviewWithError(w, r, needID, "need must be ready for review before accepting")
+			return
+		}
+		status := types.NeedStatusUnderReview
+		newStatus = &status
+		actionType = types.NeedModerationActionTypeReviewStarted
+		notice = "Review accepted"
 	case "approve":
+		if need.Status != types.NeedStatusUnderReview {
+			s.redirectAdminNeedReviewWithError(w, r, needID, "need must be under review before approval")
+			return
+		}
 		status := types.NeedStatusApproved
 		newStatus = &status
 		actionType = types.NeedModerationActionTypeReviewApproved
 		notice = "Need approved"
 	case "reject":
+		if need.Status != types.NeedStatusUnderReview {
+			s.redirectAdminNeedReviewWithError(w, r, needID, "need must be under review before rejection")
+			return
+		}
 		status := types.NeedStatusRejected
 		newStatus = &status
 		actionType = types.NeedModerationActionTypeReviewRejected
 		notice = "Need rejected"
 	case "request_changes":
+		if need.Status != types.NeedStatusUnderReview {
+			s.redirectAdminNeedReviewWithError(w, r, needID, "need must be under review before requesting changes")
+			return
+		}
 		status := types.NeedStatusChangesRequested
 		newStatus = &status
 		actionType = types.NeedModerationActionTypeChangesRequested
 		notice = "Changes requested"
 	case "verify_document":
+		if need.Status != types.NeedStatusUnderReview {
+			s.redirectAdminNeedReviewWithError(w, r, needID, "need must be under review before document verification")
+			return
+		}
 		if documentID == "" {
 			s.redirectAdminNeedReviewWithError(w, r, needID, "missing document id")
 			return
@@ -320,6 +348,10 @@ func (s *Service) handlePostAdminNeedModerate(w http.ResponseWriter, r *http.Req
 		moderationDocumentID = &documentID
 		notice = "Document verified"
 	case "reject_document":
+		if need.Status != types.NeedStatusUnderReview {
+			s.redirectAdminNeedReviewWithError(w, r, needID, "need must be under review before document rejection")
+			return
+		}
 		if documentID == "" {
 			s.redirectAdminNeedReviewWithError(w, r, needID, "missing document id")
 			return

--- a/internal/server/need_review_portal.go
+++ b/internal/server/need_review_portal.go
@@ -172,6 +172,7 @@ func (s *Service) handleGetProfileNeedReview(w http.ResponseWriter, r *http.Requ
 		CanEditNeed:         need.Status == types.NeedStatusSubmitted || need.Status == types.NeedStatusChangesRequested,
 		CanSetReady:         need.Status == types.NeedStatusSubmitted || need.Status == types.NeedStatusChangesRequested,
 		CanPullBack:         need.Status == types.NeedStatusReadyForReview,
+		CanSendMessage:      isNeedOwnerMessagingAllowedStatus(need.Status),
 		Notice:              strings.TrimSpace(r.URL.Query().Get("notice")),
 		Error:               strings.TrimSpace(r.URL.Query().Get("error")),
 	}
@@ -300,8 +301,7 @@ func (s *Service) handlePostProfileNeedReviewSetReady(w http.ResponseWriter, r *
 		return
 	}
 
-	need.Status = types.NeedStatusReadyForReview
-	if err := s.needsRepo.UpdateNeed(ctx, needID, need); err != nil {
+	if err := s.needsRepo.SetNeedStatus(ctx, needID, types.NeedStatusReadyForReview); err != nil {
 		s.logger.WithError(err).WithField("need_id", needID).Error("failed to set need status to ready for review")
 		s.internalServerError(w)
 		return
@@ -346,8 +346,7 @@ func (s *Service) handlePostProfileNeedReviewPullBack(w http.ResponseWriter, r *
 		return
 	}
 
-	need.Status = types.NeedStatusSubmitted
-	if err := s.needsRepo.UpdateNeed(ctx, needID, need); err != nil {
+	if err := s.needsRepo.SetNeedStatus(ctx, needID, types.NeedStatusSubmitted); err != nil {
 		s.logger.WithError(err).WithField("need_id", needID).Error("failed to pull need back to submitted")
 		s.internalServerError(w)
 		return

--- a/internal/server/need_review_portal.go
+++ b/internal/server/need_review_portal.go
@@ -165,8 +165,13 @@ func (s *Service) handleGetProfileNeedReview(w http.ResponseWriter, r *http.Requ
 		Documents:           docFeedback,
 		Messages:            buildNeedReviewMessageViews(messages, userID),
 		PostMessageAction:   s.route(RouteProfileNeedReviewPost, map[string]string{"needID": needID}),
+		SetReadyAction:      s.route(RouteProfileNeedReviewSetReady, map[string]string{"needID": needID}),
+		PullBackAction:      s.route(RouteProfileNeedReviewPullBack, map[string]string{"needID": needID}),
 		BackHref:            s.route(RouteProfile, nil),
 		EditNeedHref:        s.route(RouteProfileNeedEdit, map[string]string{"needID": needID}),
+		CanEditNeed:         need.Status == types.NeedStatusSubmitted || need.Status == types.NeedStatusChangesRequested,
+		CanSetReady:         need.Status == types.NeedStatusSubmitted || need.Status == types.NeedStatusChangesRequested,
+		CanPullBack:         need.Status == types.NeedStatusReadyForReview,
 		Notice:              strings.TrimSpace(r.URL.Query().Get("notice")),
 		Error:               strings.TrimSpace(r.URL.Query().Get("error")),
 	}
@@ -206,6 +211,11 @@ func (s *Service) handlePostProfileNeedReviewMessage(w http.ResponseWriter, r *h
 
 	if need.UserID != userID {
 		s.redirectProfileWithError(w, r, "You do not have permission to access that need.")
+		return
+	}
+
+	if !isNeedOwnerMessagingAllowedStatus(need.Status) {
+		s.redirectProfileNeedReviewWithError(w, r, needID, "Messages are not available for this need status.")
 		return
 	}
 
@@ -252,6 +262,107 @@ func (s *Service) handlePostProfileNeedReviewMessage(w http.ResponseWriter, r *h
 	}
 
 	s.redirectProfileNeedReviewWithNotice(w, r, needID, "Message sent to admin reviewers.")
+}
+
+func (s *Service) handlePostProfileNeedReviewSetReady(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	needID := strings.TrimSpace(r.PathValue("needID"))
+	if needID == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	userID, err := s.userIDFromContext(ctx)
+	if err != nil {
+		s.logger.WithError(err).Error("user id not found in context")
+		s.internalServerError(w)
+		return
+	}
+
+	need, err := s.needsRepo.Need(ctx, needID)
+	if err != nil {
+		if err == types.ErrNeedNotFound {
+			http.NotFound(w, r)
+			return
+		}
+		s.logger.WithError(err).WithField("need_id", needID).Error("failed to fetch need before ready-for-review transition")
+		s.internalServerError(w)
+		return
+	}
+
+	if need.UserID != userID {
+		http.NotFound(w, r)
+		return
+	}
+
+	if need.Status != types.NeedStatusSubmitted && need.Status != types.NeedStatusChangesRequested {
+		s.redirectProfileNeedReviewWithError(w, r, needID, "This need cannot be marked ready for review in its current status.")
+		return
+	}
+
+	need.Status = types.NeedStatusReadyForReview
+	if err := s.needsRepo.UpdateNeed(ctx, needID, need); err != nil {
+		s.logger.WithError(err).WithField("need_id", needID).Error("failed to set need status to ready for review")
+		s.internalServerError(w)
+		return
+	}
+
+	s.redirectProfileNeedReviewWithNotice(w, r, needID, "Need marked ready for review.")
+}
+
+func (s *Service) handlePostProfileNeedReviewPullBack(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	needID := strings.TrimSpace(r.PathValue("needID"))
+	if needID == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	userID, err := s.userIDFromContext(ctx)
+	if err != nil {
+		s.logger.WithError(err).Error("user id not found in context")
+		s.internalServerError(w)
+		return
+	}
+
+	need, err := s.needsRepo.Need(ctx, needID)
+	if err != nil {
+		if err == types.ErrNeedNotFound {
+			http.NotFound(w, r)
+			return
+		}
+		s.logger.WithError(err).WithField("need_id", needID).Error("failed to fetch need before pull-back transition")
+		s.internalServerError(w)
+		return
+	}
+
+	if need.UserID != userID {
+		http.NotFound(w, r)
+		return
+	}
+
+	if need.Status != types.NeedStatusReadyForReview {
+		s.redirectProfileNeedReviewWithError(w, r, needID, "This need cannot be pulled back in its current status.")
+		return
+	}
+
+	need.Status = types.NeedStatusSubmitted
+	if err := s.needsRepo.UpdateNeed(ctx, needID, need); err != nil {
+		s.logger.WithError(err).WithField("need_id", needID).Error("failed to pull need back to submitted")
+		s.internalServerError(w)
+		return
+	}
+
+	s.redirectProfileNeedReviewWithNotice(w, r, needID, "Need pulled back to submitted.")
+}
+
+func isNeedOwnerMessagingAllowedStatus(status types.NeedStatus) bool {
+	switch status {
+	case types.NeedStatusSubmitted, types.NeedStatusReadyForReview, types.NeedStatusUnderReview, types.NeedStatusChangesRequested, types.NeedStatusApproved, types.NeedStatusRejected:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) handleGetProfileNeedDocument(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/onboarding.go
+++ b/internal/server/onboarding.go
@@ -155,9 +155,9 @@ func (s *Service) redirectNeedOnboarding(ctx context.Context, w http.ResponseWri
 		return
 	}
 
-	// Once a need leaves draft/onboarding workflow, keep onboarding read-only and send users to confirmation.
+	// Once a need leaves draft/onboarding workflow, send users to the need review portal.
 	if need.Status != types.NeedStatusDraft {
-		http.Redirect(w, r, s.route(RouteOnboardingNeedConfirmation, map[string]string{"needID": need.ID}), http.StatusSeeOther)
+		http.Redirect(w, r, s.route(RouteProfileNeedReview, map[string]string{"needID": need.ID}), http.StatusSeeOther)
 		return
 	}
 
@@ -223,13 +223,12 @@ func (s *Service) redirectIfNeedSubmitted(w http.ResponseWriter, r *http.Request
 		return false
 	}
 
-	switch need.Status {
-	case types.NeedStatusSubmitted, types.NeedStatusReadyForReview, types.NeedStatusUnderReview, types.NeedStatusChangesRequested, types.NeedStatusApproved, types.NeedStatusRejected:
-		http.Redirect(w, r, s.route(RouteOnboardingNeedConfirmation, map[string]string{"needID": need.ID}), http.StatusSeeOther)
+	if need.Status != types.NeedStatusDraft {
+		http.Redirect(w, r, s.route(RouteProfileNeedReview, map[string]string{"needID": need.ID}), http.StatusSeeOther)
 		return true
-	default:
-		return false
 	}
+
+	return false
 }
 
 func (s *Service) handleGetOnboardingNeedWelcome(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/onboarding.go
+++ b/internal/server/onboarding.go
@@ -155,7 +155,7 @@ func (s *Service) redirectNeedOnboarding(ctx context.Context, w http.ResponseWri
 		return
 	}
 
-	if need.Status == types.NeedStatusSubmitted {
+	if need.Status == types.NeedStatusSubmitted || need.Status == types.NeedStatusReadyForReview || need.Status == types.NeedStatusUnderReview || need.Status == types.NeedStatusChangesRequested || need.Status == types.NeedStatusApproved || need.Status == types.NeedStatusRejected {
 		http.Redirect(w, r, s.route(RouteOnboardingNeedConfirmation, map[string]string{"needID": need.ID}), http.StatusSeeOther)
 		return
 	}
@@ -218,12 +218,17 @@ func (s *Service) setUserType(ctx context.Context, userType string) error {
 }
 
 func (s *Service) redirectIfNeedSubmitted(w http.ResponseWriter, r *http.Request, need *types.Need) bool {
-	if need == nil || need.Status != types.NeedStatusSubmitted {
+	if need == nil {
 		return false
 	}
 
-	http.Redirect(w, r, s.route(RouteOnboardingNeedConfirmation, map[string]string{"needID": need.ID}), http.StatusSeeOther)
-	return true
+	switch need.Status {
+	case types.NeedStatusSubmitted, types.NeedStatusReadyForReview, types.NeedStatusUnderReview, types.NeedStatusChangesRequested, types.NeedStatusApproved, types.NeedStatusRejected:
+		http.Redirect(w, r, s.route(RouteOnboardingNeedConfirmation, map[string]string{"needID": need.ID}), http.StatusSeeOther)
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) handleGetOnboardingNeedWelcome(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/onboarding.go
+++ b/internal/server/onboarding.go
@@ -155,7 +155,8 @@ func (s *Service) redirectNeedOnboarding(ctx context.Context, w http.ResponseWri
 		return
 	}
 
-	if need.Status == types.NeedStatusSubmitted || need.Status == types.NeedStatusReadyForReview || need.Status == types.NeedStatusUnderReview || need.Status == types.NeedStatusChangesRequested || need.Status == types.NeedStatusApproved || need.Status == types.NeedStatusRejected {
+	// Once a need leaves draft/onboarding workflow, keep onboarding read-only and send users to confirmation.
+	if need.Status != types.NeedStatusDraft {
 		http.Redirect(w, r, s.route(RouteOnboardingNeedConfirmation, map[string]string{"needID": need.ID}), http.StatusSeeOther)
 		return
 	}

--- a/internal/server/pages.go
+++ b/internal/server/pages.go
@@ -913,7 +913,7 @@ func browseCityStateParts(address *types.UserAddress) (string, string, string) {
 }
 
 func browseUrgency(status types.NeedStatus, amountNeededCents, amountRaisedCents int) (string, string) {
-	if status == types.NeedStatusSubmitted || status == types.NeedStatusUnderReview {
+	if status == types.NeedStatusSubmitted || status == types.NeedStatusReadyForReview || status == types.NeedStatusUnderReview {
 		return "URGENT", "bg-[color:var(--cj-error)]"
 	}
 

--- a/internal/server/profile_need_edit.go
+++ b/internal/server/profile_need_edit.go
@@ -817,7 +817,7 @@ func (s *Service) handlePostProfileNeedEditReview(w http.ResponseWriter, r *http
 
 	now := time.Now()
 	need.CurrentStep = types.NeedStepReview
-	need.Status = types.NeedStatusSubmitted
+	need.Status = types.NeedStatusReadyForReview
 	need.SubmittedAt = &now
 
 	if err := s.needsRepo.UpdateNeed(ctx, need.ID, need); err != nil {
@@ -845,7 +845,7 @@ func (s *Service) profileEditableNeed(ctx context.Context, needID string) (*type
 		return nil, types.ErrNeedNotFound
 	}
 
-	if need.Status != types.NeedStatusChangesRequested && need.Status != types.NeedStatusRejected {
+	if need.Status != types.NeedStatusSubmitted && need.Status != types.NeedStatusReadyForReview && need.Status != types.NeedStatusChangesRequested {
 		return nil, fmt.Errorf("need is not editable in its current state")
 	}
 

--- a/internal/server/profile_need_edit.go
+++ b/internal/server/profile_need_edit.go
@@ -845,7 +845,7 @@ func (s *Service) profileEditableNeed(ctx context.Context, needID string) (*type
 		return nil, types.ErrNeedNotFound
 	}
 
-	if need.Status != types.NeedStatusSubmitted && need.Status != types.NeedStatusReadyForReview && need.Status != types.NeedStatusChangesRequested {
+	if need.Status != types.NeedStatusSubmitted && need.Status != types.NeedStatusChangesRequested {
 		return nil, fmt.Errorf("need is not editable in its current state")
 	}
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -29,6 +29,8 @@ const (
 	RouteProfileNeedDelete         RouteName = "profile.need.delete"
 	RouteProfileNeedReview         RouteName = "profile.need.review"
 	RouteProfileNeedReviewPost     RouteName = "profile.need.review.post"
+	RouteProfileNeedReviewSetReady RouteName = "profile.need.review.set.ready"
+	RouteProfileNeedReviewPullBack RouteName = "profile.need.review.pull.back"
 	RouteProfileNeedDocumentView   RouteName = "profile.need.document.view"
 	RouteProfileNeedEdit           RouteName = "profile.need.edit"
 	RouteProfileNeedEditLocation   RouteName = "profile.need.edit.location"
@@ -95,6 +97,8 @@ var routePatterns = map[RouteName]string{
 	RouteProfileNeedDelete:             "/profile/needs/:needID/delete",
 	RouteProfileNeedReview:             "/profile/needs/:needID/review",
 	RouteProfileNeedReviewPost:         "/profile/needs/:needID/review/messages",
+	RouteProfileNeedReviewSetReady:     "/profile/needs/:needID/review/set-ready",
+	RouteProfileNeedReviewPullBack:     "/profile/needs/:needID/review/pull-back",
 	RouteProfileNeedDocumentView:       "/profile/needs/:needID/documents/:documentID",
 	RouteProfileNeedEdit:               "/profile/needs/:needID/edit",
 	RouteProfileNeedEditLocation:       "/profile/needs/:needID/edit/location",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -180,6 +180,8 @@ func (s *Service) buildRouter(r *flow.Mux) {
 		r.HandleFunc(RoutePattern(RouteProfileNeedDelete), s.handlePostProfileNeedDelete, http.MethodPost)
 		r.HandleFunc(RoutePattern(RouteProfileNeedReview), s.handleGetProfileNeedReview, http.MethodGet)
 		r.HandleFunc(RoutePattern(RouteProfileNeedReviewPost), s.handlePostProfileNeedReviewMessage, http.MethodPost)
+		r.HandleFunc(RoutePattern(RouteProfileNeedReviewSetReady), s.handlePostProfileNeedReviewSetReady, http.MethodPost)
+		r.HandleFunc(RoutePattern(RouteProfileNeedReviewPullBack), s.handlePostProfileNeedReviewPullBack, http.MethodPost)
 		r.HandleFunc(RoutePattern(RouteProfileNeedDocumentView), s.handleGetProfileNeedDocument, http.MethodGet)
 		r.HandleFunc(RoutePattern(RouteProfileNeedEdit), s.handleGetProfileNeedEdit, http.MethodGet)
 		r.HandleFunc(RoutePattern(RouteProfileNeedEditLocation), s.handleGetProfileNeedEditLocation, http.MethodGet)

--- a/internal/server/templates/pages/admin-need-review.html
+++ b/internal/server/templates/pages/admin-need-review.html
@@ -96,17 +96,30 @@
           <h2 class="text-base font-semibold text-foreground">Moderation Actions</h2>
           {{if .IsDeleted}}
           <p class="mt-1 text-sm text-muted-foreground">Need is deleted. Restore first before submitting moderation actions.</p>
-          {{else}}
-            <p class="mt-1 text-sm text-muted-foreground">Submit approve/reject/request changes in a focused modal.</p>
-            {{end}}
+          {{else if .CanAcceptReview}}
+            <p class="mt-1 text-sm text-muted-foreground">This need is ready for review. Accept it to lock owner edits and begin moderation.</p>
+            {{else if .CanSubmitModeration}}
+              <p class="mt-1 text-sm text-muted-foreground">Submit approve/reject/request changes in a focused modal.</p>
+              {{else}}
+                <p class="mt-1 text-sm text-muted-foreground">Moderation decisions are available only when the need is under review.</p>
+                {{end}}
         </div>
-        {{if not .IsDeleted}}
+        {{if and (not .IsDeleted) .CanSubmitModeration}}
         <button type="button" data-open-modal="need-moderation-modal"
           class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white hover:bg-[color:var(--cj-primary)]/90">
           Submit Need Review
         </button>
         {{end}}
       </div>
+
+      {{if and (not .IsDeleted) .CanAcceptReview}}
+      <form method="post" action="{{.AcceptReviewAction}}" class="mt-4">
+        <button type="submit" name="action" value="accept_review"
+          class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white hover:bg-[color:var(--cj-primary)]/90">
+          Accept Review
+        </button>
+      </form>
+      {{end}}
 
       <div class="mt-4 rounded-lg border border-border bg-card p-4">
         {{if .IsDeleted}}
@@ -153,7 +166,7 @@
               class="inline-flex h-8 items-center justify-center rounded-md border border-border bg-card px-3 text-xs font-medium text-foreground hover:bg-muted">
               Preview
             </a>
-            <button type="button" data-open-modal="document-review-modal" data-document-id="{{.ID}}" data-document-name="{{.FileName}}"
+            <button type="button" data-open-modal="document-review-modal" data-document-id="{{.ID}}" data-document-name="{{.FileName}}" {{if not $.CanSubmitModeration}}disabled{{end}}
               class="inline-flex h-8 items-center justify-center rounded-md border border-border bg-card px-3 text-xs font-medium text-foreground hover:bg-muted">
               Review Decision
             </button>

--- a/internal/server/templates/pages/profile-need-review.html
+++ b/internal/server/templates/pages/profile-need-review.html
@@ -113,6 +113,7 @@
         <p class="mt-4 text-sm text-muted-foreground">No messages yet. Send the first message if you need clarification.</p>
         {{end}}
 
+        {{if .CanSendMessage}}
         <form method="post" action="{{.PostMessageAction}}" class="mt-4 space-y-3">
           <label class="mb-1 block text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground" for="user-review-message">Message</label>
           <textarea id="user-review-message" name="message" rows="4" required class="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground"
@@ -121,6 +122,9 @@
             class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white hover:bg-[color:var(--cj-primary)]/90">Send
             Message</button>
         </form>
+        {{else}}
+        <p class="mt-4 text-sm text-muted-foreground">Messaging is unavailable for this need status.</p>
+        {{end}}
     </div>
     {{end}}
   </div>

--- a/internal/server/templates/pages/profile-need-review.html
+++ b/internal/server/templates/pages/profile-need-review.html
@@ -31,7 +31,24 @@
         <p class="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">Requested Amount</p>
         <p class="mt-1 text-sm text-foreground">${{div .Need.AmountNeededCents 100}}</p>
         <div class="mt-4 flex flex-wrap gap-2">
+          {{if .CanEditNeed}}
           <a href="{{.EditNeedHref}}" class="inline-flex h-8 items-center justify-center rounded-md border border-border px-3 text-xs font-medium text-foreground hover:bg-muted">Edit Need</a>
+          {{else}}
+            <p class="text-xs text-muted-foreground">Need editing is currently locked by status ownership.</p>
+            {{end}}
+            {{if .CanSetReady}}
+            <form method="post" action="{{.SetReadyAction}}">
+              <button type="submit"
+                class="inline-flex h-8 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-3 text-xs font-medium text-white hover:bg-[color:var(--cj-primary)]/90">Mark Ready For
+                Review</button>
+            </form>
+            {{end}}
+            {{if .CanPullBack}}
+            <form method="post" action="{{.PullBackAction}}">
+              <button type="submit" class="inline-flex h-8 items-center justify-center rounded-md border border-border px-3 text-xs font-medium text-foreground hover:bg-muted">Pull Back To
+                Submitted</button>
+            </form>
+            {{end}}
         </div>
       </div>
     </div>

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -95,7 +95,7 @@ func (r *NeedRepository) ModerationQueueNeedsPage(ctx context.Context, page, pag
 	offset := uint64((page - 1) * pageSize)
 
 	query, args, err := psql().Select(needColumns...).From(needTableName).
-		Where(sq.Eq{"status": []types.NeedStatus{types.NeedStatusSubmitted, types.NeedStatusUnderReview}}).
+		Where(sq.Eq{"status": []types.NeedStatus{types.NeedStatusReadyForReview, types.NeedStatusUnderReview}}).
 		Where(sq.Eq{"deleted_at": nil}).
 		OrderBy("submitted_at desc nulls last", "created_at desc").
 		Limit(uint64(pageSize)).
@@ -121,7 +121,7 @@ func (r *NeedRepository) ModerationQueueNeedsCount(ctx context.Context) (int, er
 	query, args, err := psql().
 		Select("COUNT(*)").
 		From(needTableName).
-		Where(sq.Eq{"status": []types.NeedStatus{types.NeedStatusSubmitted, types.NeedStatusUnderReview}}).
+		Where(sq.Eq{"status": []types.NeedStatus{types.NeedStatusReadyForReview, types.NeedStatusUnderReview}}).
 		Where(sq.Eq{"deleted_at": nil}).
 		ToSql()
 	if err != nil {

--- a/migrations/needs.pg.hcl
+++ b/migrations/needs.pg.hcl
@@ -57,7 +57,7 @@ table "needs" {
     type    = text
     null    = false
     default = "draft"
-    comment = "draft, submitted, pending_review, approved, rejected, active, funded, closed"
+    comment = "draft, submitted, ready_for_review, under_review, changes_requested, approved, rejected, active, funded, closed"
   }
 
   column "verified_at" {
@@ -178,10 +178,10 @@ table "needs" {
     where   = "deleted_at IS NOT NULL"
   }
 
-  # Speeds moderation queue pages, which always filter to non-deleted submitted/review needs.
+  # Speeds moderation queue pages, which always filter to non-deleted ready/review needs.
   index "idx_needs_queue_active" {
     columns = [column.submitted_at, column.created_at]
-    where   = "((deleted_at IS NULL) AND (status = ANY (ARRAY['SUBMITTED'::text, 'UNDER_REVIEW'::text])))"
+    where   = "((deleted_at IS NULL) AND (status = ANY (ARRAY['READY_FOR_REVIEW'::text, 'UNDER_REVIEW'::text])))"
   }
 
   # Speeds browse/latest lists that only display non-deleted, non-draft needs by recency.

--- a/migrations/needs.pg.hcl
+++ b/migrations/needs.pg.hcl
@@ -56,8 +56,8 @@ table "needs" {
   column "status" {
     type    = text
     null    = false
-    default = "draft"
-    comment = "draft, submitted, ready_for_review, under_review, changes_requested, approved, rejected, active, funded, closed"
+    default = "DRAFT"
+    comment = "DRAFT, SUBMITTED, READY_FOR_REVIEW, UNDER_REVIEW, CHANGES_REQUESTED, APPROVED, REJECTED, ACTIVE, FUNDED, CLOSED"
   }
 
   column "verified_at" {

--- a/pkg/types/need.go
+++ b/pkg/types/need.go
@@ -9,6 +9,7 @@ type NeedStatus string
 const (
 	NeedStatusDraft            NeedStatus = "DRAFT"
 	NeedStatusSubmitted        NeedStatus = "SUBMITTED"
+	NeedStatusReadyForReview   NeedStatus = "READY_FOR_REVIEW"
 	NeedStatusUnderReview      NeedStatus = "UNDER_REVIEW"
 	NeedStatusChangesRequested NeedStatus = "CHANGES_REQUESTED"
 	NeedStatusApproved         NeedStatus = "APPROVED"

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -368,6 +368,7 @@ type NeedReviewPortalPageData struct {
 	CanEditNeed         bool
 	CanSetReady         bool
 	CanPullBack         bool
+	CanSendMessage      bool
 	Notice              string
 	Error               string
 }

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -361,8 +361,13 @@ type NeedReviewPortalPageData struct {
 	Documents           []NeedReviewDocumentFeedback
 	Messages            []NeedReviewMessageView
 	PostMessageAction   string
+	SetReadyAction      string
+	PullBackAction      string
 	BackHref            string
 	EditNeedHref        string
+	CanEditNeed         bool
+	CanSetReady         bool
+	CanPullBack         bool
 	Notice              string
 	Error               string
 }
@@ -413,6 +418,9 @@ type AdminNeedReviewPageData struct {
 	Timeline            []*AdminNeedTimelineItem
 	BackHref            string
 	ModerateAction      string
+	AcceptReviewAction  string
+	CanAcceptReview     bool
+	CanSubmitModeration bool
 	DeleteAction        string
 	RestoreAction       string
 	IsDeleted           bool


### PR DESCRIPTION
## Summary
- Enforces draft-only editability in onboarding redirect logic.
- Keeps onboarding read-only once a need leaves DRAFT by redirecting to confirmation.
- Adds a concise code comment documenting this guard intent.

## Why
- The ownership model treats onboarding as the draft workflow only.
- A non-DRAFT check is simpler and automatically covers future statuses.

## Testing
- go test -count=1 ./...

## References
- Closes #10
- ADR: docs/adr/0002-need-review-state-ownership-and-handoffs.md
