### PR TITLE
refactor(issue-28): consolidate need review portal data loading

### DIFF
--- a/internal/server/need_review_portal.go
+++ b/internal/server/need_review_portal.go
@@ -34,7 +34,7 @@ func (s *Service) handleGetProfileNeedReview(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	need, err := s.needsRepo.Need(ctx, needID)
+	shared, err := s.loadNeedReviewSharedData(ctx, needID)
 	if err != nil {
 		if err == types.ErrNeedNotFound {
 			http.NotFound(w, r)
@@ -45,64 +45,10 @@ func (s *Service) handleGetProfileNeedReview(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	need := shared.Need
 	if need.UserID != userID {
 		s.redirectProfileWithError(w, r, "You do not have permission to access that need.")
 		return
-	}
-
-	story, err := s.storyRepo.GetStoryByNeedID(ctx, needID)
-	if err != nil {
-		s.logger.WithError(err).WithField("need_id", needID).Error("failed to fetch story for review portal")
-		s.internalServerError(w)
-		return
-	}
-
-	assignments, err := s.needCategoryAssignmentsRepo.GetAssignmentsByNeedID(ctx, needID)
-	if err != nil {
-		s.logger.WithError(err).WithField("need_id", needID).Error("failed to fetch category assignments for review portal")
-		s.internalServerError(w)
-		return
-	}
-
-	categoryIDs := make([]string, 0, len(assignments))
-	for _, assignment := range assignments {
-		categoryID := strings.TrimSpace(assignment.CategoryID)
-		if categoryID != "" {
-			categoryIDs = append(categoryIDs, categoryID)
-		}
-	}
-
-	categoryByID := make(map[string]*types.NeedCategory)
-	if len(categoryIDs) > 0 {
-		categories, err := s.categoryRepo.CategoriesByIDs(ctx, categoryIDs)
-		if err != nil {
-			s.logger.WithError(err).WithField("need_id", needID).Error("failed to fetch categories for review portal")
-			s.internalServerError(w)
-			return
-		}
-
-		for _, category := range categories {
-			if category == nil {
-				continue
-			}
-			categoryByID[category.ID] = category
-		}
-	}
-
-	var primaryCategory *types.NeedCategory
-	secondaryCategories := make([]*types.NeedCategory, 0)
-	for _, assignment := range assignments {
-		category := categoryByID[assignment.CategoryID]
-		if category == nil {
-			continue
-		}
-
-		if assignment.IsPrimary {
-			primaryCategory = category
-			continue
-		}
-
-		secondaryCategories = append(secondaryCategories, category)
 	}
 
 	actions, err := s.progressRepo.ModerationActionsByNeed(ctx, needID)
@@ -115,15 +61,8 @@ func (s *Service) handleGetProfileNeedReview(w http.ResponseWriter, r *http.Requ
 	rejectionReason, rejectionNote, rejectedDocumentByID := latestRejectedFeedback(actions)
 	documentStatusByID := latestDocumentStatuses(actions)
 
-	docs, err := s.documentRepo.DocumentsByNeedID(ctx, needID)
-	if err != nil {
-		s.logger.WithError(err).WithField("need_id", needID).Error("failed to fetch documents for review portal")
-		s.internalServerError(w)
-		return
-	}
-
-	docFeedback := make([]types.NeedReviewDocumentFeedback, 0, len(docs))
-	for _, doc := range docs {
+	docFeedback := make([]types.NeedReviewDocumentFeedback, 0, len(shared.Documents))
+	for _, doc := range shared.Documents {
 		status := "Pending Review"
 		if value, ok := documentStatusByID[doc.ID]; ok {
 			status = value
@@ -157,9 +96,9 @@ func (s *Service) handleGetProfileNeedReview(w http.ResponseWriter, r *http.Requ
 	data := &types.NeedReviewPortalPageData{
 		BasePageData:        types.BasePageData{Title: "Need Review Portal"},
 		Need:                need,
-		Story:               story,
-		PrimaryCategory:     primaryCategory,
-		SecondaryCategories: secondaryCategories,
+		Story:               shared.Story,
+		PrimaryCategory:     shared.PrimaryCategory,
+		SecondaryCategories: shared.SecondaryCategories,
 		RejectionReason:     rejectionReason,
 		RejectionNote:       rejectionNote,
 		Documents:           docFeedback,

--- a/internal/server/need_review_portal.go
+++ b/internal/server/need_review_portal.go
@@ -40,7 +40,7 @@ func (s *Service) handleGetProfileNeedReview(w http.ResponseWriter, r *http.Requ
 			http.NotFound(w, r)
 			return
 		}
-		s.logger.WithError(err).WithField("need_id", needID).Error("failed to fetch need for review portal")
+		s.logger.WithError(err).WithField("need_id", needID).Error("failed to load shared need review data for review portal")
 		s.internalServerError(w)
 		return
 	}

--- a/internal/server/profile_need_edit.go
+++ b/internal/server/profile_need_edit.go
@@ -24,6 +24,14 @@ type needReviewCoreData struct {
 	Documents           []types.ReviewDocument
 }
 
+type needReviewSharedData struct {
+	Need                *types.Need
+	Story               *types.NeedStory
+	PrimaryCategory     *types.NeedCategory
+	SecondaryCategories []*types.NeedCategory
+	Documents           []types.NeedDocument
+}
+
 func (s *Service) handleGetProfileNeedEdit(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	needID := strings.TrimSpace(r.PathValue("needID"))
@@ -853,6 +861,41 @@ func (s *Service) profileEditableNeed(ctx context.Context, needID string) (*type
 }
 
 func (s *Service) loadNeedReviewCoreData(ctx context.Context, needID string) (*needReviewCoreData, error) {
+	shared, err := s.loadNeedReviewSharedData(ctx, needID)
+	if err != nil {
+		return nil, err
+	}
+
+	var selectedAddress *types.UserAddress
+	if shared.Need.UserAddressID != nil && *shared.Need.UserAddressID != "" {
+		selectedAddress, err = s.userAddressRepo.ByIDAndUserID(ctx, *shared.Need.UserAddressID, shared.Need.UserID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if selectedAddress == nil {
+		selectedAddress, err = s.userAddressRepo.PrimaryByUserID(ctx, shared.Need.UserID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	reviewDocs := make([]types.ReviewDocument, 0, len(shared.Documents))
+	for _, doc := range shared.Documents {
+		reviewDocs = append(reviewDocs, types.ReviewDocument{ID: doc.ID, FileName: doc.FileName, TypeLabel: documentTypeLabel(doc.DocumentType), SizeBytes: doc.FileSizeBytes, UploadedAt: doc.UploadedAt})
+	}
+
+	return &needReviewCoreData{
+		Need:                shared.Need,
+		Story:               shared.Story,
+		PrimaryCategory:     shared.PrimaryCategory,
+		SecondaryCategories: shared.SecondaryCategories,
+		SelectedAddress:     selectedAddress,
+		Documents:           reviewDocs,
+	}, nil
+}
+
+func (s *Service) loadNeedReviewSharedData(ctx context.Context, needID string) (*needReviewSharedData, error) {
 	need, err := s.needsRepo.Need(ctx, needID)
 	if err != nil {
 		return nil, err
@@ -868,18 +911,25 @@ func (s *Service) loadNeedReviewCoreData(ctx context.Context, needID string) (*n
 		return nil, err
 	}
 
-	ids := make([]string, 0, len(assignments))
+	categoryIDs := make([]string, 0, len(assignments))
 	for _, assignment := range assignments {
-		ids = append(ids, assignment.CategoryID)
+		categoryID := strings.TrimSpace(assignment.CategoryID)
+		if categoryID == "" {
+			continue
+		}
+		categoryIDs = append(categoryIDs, categoryID)
 	}
 
 	categoryByID := make(map[string]*types.NeedCategory)
-	if len(ids) > 0 {
-		categories, err := s.categoryRepo.CategoriesByIDs(ctx, ids)
+	if len(categoryIDs) > 0 {
+		categories, err := s.categoryRepo.CategoriesByIDs(ctx, categoryIDs)
 		if err != nil {
 			return nil, err
 		}
 		for _, category := range categories {
+			if category == nil {
+				continue
+			}
 			categoryByID[category.ID] = category
 		}
 	}
@@ -887,8 +937,8 @@ func (s *Service) loadNeedReviewCoreData(ctx context.Context, needID string) (*n
 	var primaryCategory *types.NeedCategory
 	secondaryCategories := make([]*types.NeedCategory, 0)
 	for _, assignment := range assignments {
-		category, ok := categoryByID[assignment.CategoryID]
-		if !ok {
+		category := categoryByID[assignment.CategoryID]
+		if category == nil {
 			continue
 		}
 		if assignment.IsPrimary {
@@ -898,37 +948,17 @@ func (s *Service) loadNeedReviewCoreData(ctx context.Context, needID string) (*n
 		secondaryCategories = append(secondaryCategories, category)
 	}
 
-	var selectedAddress *types.UserAddress
-	if need.UserAddressID != nil && *need.UserAddressID != "" {
-		selectedAddress, err = s.userAddressRepo.ByIDAndUserID(ctx, *need.UserAddressID, need.UserID)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if selectedAddress == nil {
-		selectedAddress, err = s.userAddressRepo.PrimaryByUserID(ctx, need.UserID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	docs, err := s.documentRepo.DocumentsByNeedID(ctx, needID)
+	documents, err := s.documentRepo.DocumentsByNeedID(ctx, needID)
 	if err != nil {
 		return nil, err
 	}
 
-	reviewDocs := make([]types.ReviewDocument, 0, len(docs))
-	for _, doc := range docs {
-		reviewDocs = append(reviewDocs, types.ReviewDocument{ID: doc.ID, FileName: doc.FileName, TypeLabel: documentTypeLabel(doc.DocumentType), SizeBytes: doc.FileSizeBytes, UploadedAt: doc.UploadedAt})
-	}
-
-	return &needReviewCoreData{
+	return &needReviewSharedData{
 		Need:                need,
 		Story:               story,
 		PrimaryCategory:     primaryCategory,
 		SecondaryCategories: secondaryCategories,
-		SelectedAddress:     selectedAddress,
-		Documents:           reviewDocs,
+		Documents:           documents,
 	}, nil
 }
 

--- a/internal/server/profile_need_edit.go
+++ b/internal/server/profile_need_edit.go
@@ -937,7 +937,12 @@ func (s *Service) loadNeedReviewSharedData(ctx context.Context, needID string) (
 	var primaryCategory *types.NeedCategory
 	secondaryCategories := make([]*types.NeedCategory, 0)
 	for _, assignment := range assignments {
-		category := categoryByID[assignment.CategoryID]
+		categoryID := strings.TrimSpace(assignment.CategoryID)
+		if categoryID == "" {
+			continue
+		}
+
+		category := categoryByID[categoryID]
 		if category == nil {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Consolidates duplicated need review data loading logic used by both review portal and profile edit review paths.
- Introduces a shared loader that returns need, story, category breakdown, and documents in one place.
- Keeps existing handler behavior while removing repeated query and mapping code.

## Changes
- Added loadNeedReviewSharedData in internal/server/profile_need_edit.go.
- Updated loadNeedReviewCoreData to build on the shared loader and keep address/review-doc shaping local.
- Updated handleGetProfileNeedReview in internal/server/need_review_portal.go to use shared loader output.

## Testing
- go test -count=1 ./internal/server/... ./pkg/...

## References
- Closes #28
