### PR TITLE
feat(issue-24): add admin need explorer

### DIFF
--- a/internal/seed/needs.go
+++ b/internal/seed/needs.go
@@ -34,8 +34,7 @@ var weightedStatuses = []weightedNeedStatus{
 	{Status: types.NeedStatusDraft, Weight: 35},
 	{Status: types.NeedStatusSubmitted, Weight: 20},
 	{Status: types.NeedStatusUnderReview, Weight: 15},
-	{Status: types.NeedStatusApproved, Weight: 10},
-	{Status: types.NeedStatusActive, Weight: 12},
+	{Status: types.NeedStatusActive, Weight: 22},
 	{Status: types.NeedStatusFunded, Weight: 8},
 }
 
@@ -86,7 +85,7 @@ func SeedFakeNeeds(
 		switch status {
 		case types.NeedStatusFunded:
 			amountRaised = amountNeeded
-		case types.NeedStatusActive, types.NeedStatusApproved:
+		case types.NeedStatusActive:
 			amountRaised = rng.Intn(max(amountNeeded-100, 100))
 		case types.NeedStatusUnderReview, types.NeedStatusSubmitted:
 			amountRaised = rng.Intn(max(amountNeeded/3, 100))
@@ -109,7 +108,7 @@ func SeedFakeNeeds(
 		if status != types.NeedStatusDraft {
 			need.SubmittedAt = utils.TimePtr(now.Add(-time.Duration(rng.Intn(14*24)) * time.Hour))
 		}
-		if status == types.NeedStatusApproved || status == types.NeedStatusActive || status == types.NeedStatusFunded {
+		if status == types.NeedStatusActive || status == types.NeedStatusFunded {
 			verifiedBy := fakeNeedUserIDs[rng.Intn(len(fakeNeedUserIDs))]
 			need.VerifiedBy = utils.StringPtr(verifiedBy)
 			need.VerifiedAt = utils.TimePtr(now.Add(-time.Duration(rng.Intn(10*24)) * time.Hour))
@@ -201,7 +200,7 @@ func stepForStatus(status types.NeedStatus, rng *rand.Rand) types.NeedStep {
 		return steps[rng.Intn(len(steps))]
 	case types.NeedStatusSubmitted, types.NeedStatusUnderReview:
 		return types.NeedStepReview
-	case types.NeedStatusApproved, types.NeedStatusActive, types.NeedStatusFunded:
+	case types.NeedStatusActive, types.NeedStatusFunded:
 		return types.NeedStepComplete
 	default:
 		return types.NeedStepReview

--- a/internal/server/admin_need_explorer.go
+++ b/internal/server/admin_need_explorer.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"christjesus/pkg/types"
+)
+
+const (
+	adminNeedExplorerPageSize = 20
+	adminExplorerSortUpdated  = "updated_desc"
+)
+
+func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	page := parsePositiveInt(r.URL.Query().Get("page"), 1)
+	selectedStatus := strings.TrimSpace(r.URL.Query().Get("status"))
+	selectedSort := strings.TrimSpace(r.URL.Query().Get("sort"))
+	if selectedSort == "" {
+		selectedSort = adminExplorerSortUpdated
+	}
+
+	statusFilter := adminExplorerStatusFilter(selectedStatus)
+	totalNeeds, err := s.needsRepo.AdminExplorerNeedsCount(ctx, statusFilter)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to count needs for admin explorer")
+		s.internalServerError(w)
+		return
+	}
+
+	totalPages := totalNeeds / adminNeedExplorerPageSize
+	if totalNeeds%adminNeedExplorerPageSize != 0 {
+		totalPages++
+	}
+	if totalPages == 0 {
+		totalPages = 1
+	}
+	if page > totalPages {
+		page = totalPages
+	}
+
+	needs, err := s.needsRepo.AdminExplorerNeedsPage(ctx, page, adminNeedExplorerPageSize, statusFilter, selectedSort)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to fetch needs for admin explorer")
+		s.internalServerError(w)
+		return
+	}
+
+	items := make([]*types.AdminNeedExplorerItem, 0, len(needs))
+	for _, need := range needs {
+		if need == nil {
+			continue
+		}
+
+		needID := strings.TrimSpace(need.ID)
+		if needID == "" {
+			continue
+		}
+
+		publishedAt := "-"
+		if need.PublishedAt != nil {
+			publishedAt = need.PublishedAt.Format(time.DateOnly)
+		}
+
+		fundingPercent := needFundingPercent(need.AmountRaisedCents, need.AmountNeededCents)
+		items = append(items, &types.AdminNeedExplorerItem{
+			NeedID:            needID,
+			Status:            need.Status,
+			AmountRaisedCents: need.AmountRaisedCents,
+			AmountNeededCents: need.AmountNeededCents,
+			FundingPercent:    fundingPercent,
+			ActivityLabel:     fundingActivityLabel(fundingPercent),
+			UpdatedAt:         need.UpdatedAt.Format(time.DateOnly),
+			PublishedAt:       publishedAt,
+			ReviewHref:        s.route(RouteAdminNeedReview, map[string]string{"id": needID}),
+			DetailHref:        s.route(RouteNeedDetail, map[string]string{"id": needID}),
+		})
+	}
+
+	buildPageHref := func(nextPage int) string {
+		v := url.Values{}
+		v.Set("page", strconv.Itoa(nextPage))
+		if selectedStatus != "" {
+			v.Set("status", selectedStatus)
+		}
+		if selectedSort != "" {
+			v.Set("sort", selectedSort)
+		}
+		return s.routeWithQuery(RouteAdminNeedExplorer, nil, v)
+	}
+
+	prevHref := ""
+	if page > 1 {
+		prevHref = buildPageHref(page - 1)
+	}
+
+	nextHref := ""
+	if page < totalPages {
+		nextHref = buildPageHref(page + 1)
+	}
+
+	data := &types.AdminNeedExplorerPageData{
+		BasePageData:     types.BasePageData{Title: "Admin Need Explorer"},
+		Needs:            items,
+		Page:             page,
+		PageSize:         adminNeedExplorerPageSize,
+		TotalNeeds:       totalNeeds,
+		TotalPages:       totalPages,
+		PrevHref:         prevHref,
+		NextHref:         nextHref,
+		SelectedStatus:   selectedStatus,
+		SelectedSort:     selectedSort,
+		FilterAction:     s.route(RouteAdminNeedExplorer, nil),
+		StatusOptions:    adminExplorerStatusOptions(),
+		SortOptions:      adminExplorerSortOptions(),
+		BackHref:         s.route(RouteAdmin, nil),
+		QueueHref:        s.route(RouteAdminNeeds, nil),
+		CurrentStatusText: adminExplorerStatusLabel(selectedStatus),
+	}
+
+	if err := s.renderTemplate(w, r, "page.admin.need.explorer", data); err != nil {
+		s.logger.WithError(err).Error("failed to render admin need explorer page")
+		s.internalServerError(w)
+		return
+	}
+}
+
+func adminExplorerStatusFilter(raw string) *types.NeedStatus {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case string(types.NeedStatusApproved):
+		status := types.NeedStatusApproved
+		return &status
+	case string(types.NeedStatusActive):
+		status := types.NeedStatusActive
+		return &status
+	case string(types.NeedStatusFunded):
+		status := types.NeedStatusFunded
+		return &status
+	default:
+		return nil
+	}
+}
+
+func adminExplorerStatusLabel(raw string) string {
+	status := adminExplorerStatusFilter(raw)
+	if status == nil {
+		return "All post-approval statuses"
+	}
+	return string(*status)
+}
+
+func adminExplorerStatusOptions() []types.AdminExplorerOption {
+	return []types.AdminExplorerOption{
+		{Value: "", Label: "All post-approval"},
+		{Value: string(types.NeedStatusApproved), Label: "Approved"},
+		{Value: string(types.NeedStatusActive), Label: "Active"},
+		{Value: string(types.NeedStatusFunded), Label: "Funded"},
+	}
+}
+
+func adminExplorerSortOptions() []types.AdminExplorerOption {
+	return []types.AdminExplorerOption{
+		{Value: "updated_desc", Label: "Recently Updated"},
+		{Value: "updated_asc", Label: "Oldest Updated"},
+		{Value: "progress_desc", Label: "Highest % Funded"},
+		{Value: "raised_desc", Label: "Most Raised"},
+		{Value: "needed_desc", Label: "Largest Goal"},
+	}
+}
+
+func needFundingPercent(raisedCents, neededCents int) int {
+	if neededCents <= 0 {
+		return 0
+	}
+	percent := (raisedCents * 100) / neededCents
+	if percent < 0 {
+		return 0
+	}
+	if percent > 100 {
+		return 100
+	}
+	return percent
+}
+
+func fundingActivityLabel(percent int) string {
+	switch {
+	case percent >= 75:
+		return "High"
+	case percent >= 25:
+		return "Medium"
+	default:
+		return "Low"
+	}
+}

--- a/internal/server/admin_need_explorer.go
+++ b/internal/server/admin_need_explorer.go
@@ -25,6 +25,13 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 	}
 
 	statusFilter := adminExplorerStatusFilter(selectedStatus)
+	statusCounts, err := s.needsRepo.AdminExplorerNeedsCountByStatus(ctx)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to fetch grouped status counts for admin explorer")
+		s.internalServerError(w)
+		return
+	}
+
 	totalNeeds, err := s.needsRepo.AdminExplorerNeedsCount(ctx, statusFilter)
 	if err != nil {
 		s.logger.WithError(err).Error("failed to count needs for admin explorer")
@@ -103,9 +110,35 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 		nextHref = buildPageHref(page + 1)
 	}
 
+	statusCards := make([]*types.AdminNeedStatusCard, 0, len(adminExplorerStatusOptions()))
+	for _, option := range adminExplorerStatusOptions() {
+		status := types.NeedStatus(option.Value)
+		count := totalNeeds
+		if strings.TrimSpace(option.Value) != "" {
+			count = statusCounts[status]
+		}
+
+		v := url.Values{}
+		if strings.TrimSpace(option.Value) != "" {
+			v.Set("status", option.Value)
+		}
+		if selectedSort != "" {
+			v.Set("sort", selectedSort)
+		}
+
+		statusCards = append(statusCards, &types.AdminNeedStatusCard{
+			Status:   status,
+			Label:    option.Label,
+			Count:    count,
+			Href:     s.routeWithQuery(RouteAdminNeedExplorer, nil, v),
+			IsActive: strings.EqualFold(strings.TrimSpace(selectedStatus), option.Value),
+		})
+	}
+
 	data := &types.AdminNeedExplorerPageData{
 		BasePageData:      types.BasePageData{Title: "Admin Need Explorer"},
 		Needs:             items,
+		StatusCards:       statusCards,
 		Page:              page,
 		PageSize:          adminNeedExplorerPageSize,
 		TotalNeeds:        totalNeeds,

--- a/internal/server/admin_need_explorer.go
+++ b/internal/server/admin_need_explorer.go
@@ -18,13 +18,8 @@ const (
 func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	page := parsePositiveInt(r.URL.Query().Get("page"), 1)
-	selectedStatus := strings.TrimSpace(r.URL.Query().Get("status"))
-	selectedSort := strings.TrimSpace(r.URL.Query().Get("sort"))
-	if selectedSort == "" {
-		selectedSort = adminExplorerSortUpdated
-	}
-
-	statusFilter := adminExplorerStatusFilter(selectedStatus)
+	selectedStatus, statusFilter := canonicalAdminExplorerStatus(r.URL.Query().Get("status"))
+	selectedSort := canonicalAdminExplorerSort(r.URL.Query().Get("sort"))
 	statusCounts, err := s.needsRepo.AdminExplorerNeedsCountByStatus(ctx)
 	if err != nil {
 		s.logger.WithError(err).Error("failed to fetch grouped status counts for admin explorer")
@@ -57,6 +52,12 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if err := s.applyFinalizedRaisedAmounts(ctx, needs); err != nil {
+		s.logger.WithError(err).Error("failed to apply finalized raised amounts for admin explorer")
+		s.internalServerError(w)
+		return
+	}
+
 	items := make([]*types.AdminNeedExplorerItem, 0, len(needs))
 	for _, need := range needs {
 		if need == nil {
@@ -73,7 +74,7 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 			publishedAt = need.PublishedAt.Format(time.DateOnly)
 		}
 
-		fundingPercent := needFundingPercent(need.AmountRaisedCents, need.AmountNeededCents)
+		fundingPercent := fundingPercentFromCents(need.AmountRaisedCents, need.AmountNeededCents)
 		items = append(items, &types.AdminNeedExplorerItem{
 			NeedID:            needID,
 			Status:            need.Status,
@@ -85,6 +86,7 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 			PublishedAt:       publishedAt,
 			ReviewHref:        s.route(RouteAdminNeedReview, map[string]string{"id": needID}),
 			DetailHref:        s.route(RouteNeedDetail, map[string]string{"id": needID}),
+			CanViewDetail:     adminExplorerCanViewPublicDetail(need.Status),
 		})
 	}
 
@@ -131,7 +133,7 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 			Label:    option.Label,
 			Count:    count,
 			Href:     s.routeWithQuery(RouteAdminNeedExplorer, nil, v),
-			IsActive: strings.EqualFold(strings.TrimSpace(selectedStatus), option.Value),
+			IsActive: selectedStatus == option.Value,
 		})
 	}
 
@@ -152,7 +154,7 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 		SortOptions:       adminExplorerSortOptions(),
 		BackHref:          s.route(RouteAdmin, nil),
 		QueueHref:         s.route(RouteAdminNeeds, nil),
-		CurrentStatusText: adminExplorerStatusLabel(selectedStatus),
+		CurrentStatusText: adminExplorerStatusLabelByValue(selectedStatus),
 	}
 
 	if err := s.renderTemplate(w, r, "page.admin.need.explorer", data); err != nil {
@@ -196,12 +198,38 @@ func adminExplorerStatusFilter(raw string) *types.NeedStatus {
 	}
 }
 
-func adminExplorerStatusLabel(raw string) string {
+func canonicalAdminExplorerStatus(raw string) (string, *types.NeedStatus) {
 	status := adminExplorerStatusFilter(raw)
 	if status == nil {
-		return "All statuses"
+		return "", nil
 	}
-	return string(*status)
+
+	canonical := string(*status)
+	return canonical, status
+}
+
+func canonicalAdminExplorerSort(raw string) string {
+	selected := strings.TrimSpace(raw)
+	if selected == "" {
+		return adminExplorerSortUpdated
+	}
+
+	for _, option := range adminExplorerSortOptions() {
+		if option.Value == selected {
+			return selected
+		}
+	}
+
+	return adminExplorerSortUpdated
+}
+
+func adminExplorerStatusLabelByValue(value string) string {
+	for _, option := range adminExplorerStatusOptions() {
+		if option.Value == value {
+			return option.Label
+		}
+	}
+	return "All statuses"
 }
 
 func adminExplorerStatusOptions() []types.AdminExplorerOption {
@@ -229,18 +257,13 @@ func adminExplorerSortOptions() []types.AdminExplorerOption {
 	}
 }
 
-func needFundingPercent(raisedCents, neededCents int) int {
-	if neededCents <= 0 {
-		return 0
+func adminExplorerCanViewPublicDetail(status types.NeedStatus) bool {
+	switch status {
+	case types.NeedStatusActive, types.NeedStatusFunded:
+		return true
+	default:
+		return false
 	}
-	percent := (raisedCents * 100) / neededCents
-	if percent < 0 {
-		return 0
-	}
-	if percent > 100 {
-		return 100
-	}
-	return percent
 }
 
 func fundingActivityLabel(percent int) string {

--- a/internal/server/admin_need_explorer.go
+++ b/internal/server/admin_need_explorer.go
@@ -184,9 +184,6 @@ func adminExplorerStatusFilter(raw string) *types.NeedStatus {
 	case string(types.NeedStatusRejected):
 		status := types.NeedStatusRejected
 		return &status
-	case string(types.NeedStatusApproved):
-		status := types.NeedStatusApproved
-		return &status
 	case string(types.NeedStatusActive):
 		status := types.NeedStatusActive
 		return &status
@@ -241,7 +238,6 @@ func adminExplorerStatusOptions() []types.AdminExplorerOption {
 		{Value: string(types.NeedStatusUnderReview), Label: "Under Review"},
 		{Value: string(types.NeedStatusChangesRequested), Label: "Changes Requested"},
 		{Value: string(types.NeedStatusRejected), Label: "Rejected"},
-		{Value: string(types.NeedStatusApproved), Label: "Approved"},
 		{Value: string(types.NeedStatusActive), Label: "Active"},
 		{Value: string(types.NeedStatusFunded), Label: "Funded"},
 	}

--- a/internal/server/admin_need_explorer.go
+++ b/internal/server/admin_need_explorer.go
@@ -104,21 +104,21 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 	}
 
 	data := &types.AdminNeedExplorerPageData{
-		BasePageData:     types.BasePageData{Title: "Admin Need Explorer"},
-		Needs:            items,
-		Page:             page,
-		PageSize:         adminNeedExplorerPageSize,
-		TotalNeeds:       totalNeeds,
-		TotalPages:       totalPages,
-		PrevHref:         prevHref,
-		NextHref:         nextHref,
-		SelectedStatus:   selectedStatus,
-		SelectedSort:     selectedSort,
-		FilterAction:     s.route(RouteAdminNeedExplorer, nil),
-		StatusOptions:    adminExplorerStatusOptions(),
-		SortOptions:      adminExplorerSortOptions(),
-		BackHref:         s.route(RouteAdmin, nil),
-		QueueHref:        s.route(RouteAdminNeeds, nil),
+		BasePageData:      types.BasePageData{Title: "Admin Need Explorer"},
+		Needs:             items,
+		Page:              page,
+		PageSize:          adminNeedExplorerPageSize,
+		TotalNeeds:        totalNeeds,
+		TotalPages:        totalPages,
+		PrevHref:          prevHref,
+		NextHref:          nextHref,
+		SelectedStatus:    selectedStatus,
+		SelectedSort:      selectedSort,
+		FilterAction:      s.route(RouteAdminNeedExplorer, nil),
+		StatusOptions:     adminExplorerStatusOptions(),
+		SortOptions:       adminExplorerSortOptions(),
+		BackHref:          s.route(RouteAdmin, nil),
+		QueueHref:         s.route(RouteAdminNeeds, nil),
 		CurrentStatusText: adminExplorerStatusLabel(selectedStatus),
 	}
 
@@ -131,6 +131,24 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 
 func adminExplorerStatusFilter(raw string) *types.NeedStatus {
 	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case string(types.NeedStatusDraft):
+		status := types.NeedStatusDraft
+		return &status
+	case string(types.NeedStatusSubmitted):
+		status := types.NeedStatusSubmitted
+		return &status
+	case string(types.NeedStatusReadyForReview):
+		status := types.NeedStatusReadyForReview
+		return &status
+	case string(types.NeedStatusUnderReview):
+		status := types.NeedStatusUnderReview
+		return &status
+	case string(types.NeedStatusChangesRequested):
+		status := types.NeedStatusChangesRequested
+		return &status
+	case string(types.NeedStatusRejected):
+		status := types.NeedStatusRejected
+		return &status
 	case string(types.NeedStatusApproved):
 		status := types.NeedStatusApproved
 		return &status
@@ -148,14 +166,20 @@ func adminExplorerStatusFilter(raw string) *types.NeedStatus {
 func adminExplorerStatusLabel(raw string) string {
 	status := adminExplorerStatusFilter(raw)
 	if status == nil {
-		return "All post-approval statuses"
+		return "All statuses"
 	}
 	return string(*status)
 }
 
 func adminExplorerStatusOptions() []types.AdminExplorerOption {
 	return []types.AdminExplorerOption{
-		{Value: "", Label: "All post-approval"},
+		{Value: "", Label: "All statuses"},
+		{Value: string(types.NeedStatusDraft), Label: "Draft"},
+		{Value: string(types.NeedStatusSubmitted), Label: "Submitted"},
+		{Value: string(types.NeedStatusReadyForReview), Label: "Ready For Review"},
+		{Value: string(types.NeedStatusUnderReview), Label: "Under Review"},
+		{Value: string(types.NeedStatusChangesRequested), Label: "Changes Requested"},
+		{Value: string(types.NeedStatusRejected), Label: "Rejected"},
 		{Value: string(types.NeedStatusApproved), Label: "Approved"},
 		{Value: string(types.NeedStatusActive), Label: "Active"},
 		{Value: string(types.NeedStatusFunded), Label: "Funded"},

--- a/internal/server/admin_need_review.go
+++ b/internal/server/admin_need_review.go
@@ -306,10 +306,8 @@ func (s *Service) handlePostAdminNeedModerate(w http.ResponseWriter, r *http.Req
 			s.redirectAdminNeedReviewWithError(w, r, needID, "need must be under review before approval")
 			return
 		}
-		status := types.NeedStatusApproved
-		newStatus = &status
 		actionType = types.NeedModerationActionTypeReviewApproved
-		notice = "Need approved"
+		notice = "Need approved and published"
 	case "reject":
 		if need.Status != types.NeedStatusUnderReview {
 			s.redirectAdminNeedReviewWithError(w, r, needID, "need must be under review before rejection")
@@ -388,7 +386,11 @@ func (s *Service) handlePostAdminNeedModerate(w http.ResponseWriter, r *http.Req
 	}
 
 	if err := store.WithTx(r.Context(), s.needsRepo, func(tx pgx.Tx) error {
-		if newStatus != nil {
+		if action == "approve" {
+			if err := s.needsRepo.PublishNeedTx(r.Context(), tx, needID); err != nil {
+				return err
+			}
+		} else if newStatus != nil {
 			if err := s.needsRepo.SetNeedStatusTx(r.Context(), tx, needID, *newStatus); err != nil {
 				return err
 			}

--- a/internal/server/need_review_portal.go
+++ b/internal/server/need_review_portal.go
@@ -296,7 +296,7 @@ func (s *Service) handlePostProfileNeedReviewPullBack(w http.ResponseWriter, r *
 
 func isNeedOwnerMessagingAllowedStatus(status types.NeedStatus) bool {
 	switch status {
-	case types.NeedStatusSubmitted, types.NeedStatusReadyForReview, types.NeedStatusUnderReview, types.NeedStatusChangesRequested, types.NeedStatusApproved, types.NeedStatusRejected:
+	case types.NeedStatusSubmitted, types.NeedStatusReadyForReview, types.NeedStatusUnderReview, types.NeedStatusChangesRequested, types.NeedStatusRejected:
 		return true
 	default:
 		return false

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -20,6 +20,7 @@ const (
 	RouteProfile                   RouteName = "profile"
 	RouteAdmin                     RouteName = "admin.dashboard"
 	RouteAdminNeeds                RouteName = "admin.needs"
+	RouteAdminNeedExplorer         RouteName = "admin.need.explorer"
 	RouteAdminNeedReview           RouteName = "admin.need.review"
 	RouteAdminNeedModerate         RouteName = "admin.need.moderate"
 	RouteAdminNeedDocument         RouteName = "admin.need.document"
@@ -88,6 +89,7 @@ var routePatterns = map[RouteName]string{
 	RouteProfile:                       "/profile",
 	RouteAdmin:                         "/admin",
 	RouteAdminNeeds:                    "/admin/needs",
+	RouteAdminNeedExplorer:             "/admin/needs/explorer",
 	RouteAdminNeedReview:               "/admin/needs/:id",
 	RouteAdminNeedModerate:             "/admin/needs/:id/moderate",
 	RouteAdminNeedDocument:             "/admin/needs/:id/documents/:documentID",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -235,6 +235,7 @@ func (s *Service) buildRouter(r *flow.Mux) {
 
 		r.HandleFunc(RoutePattern(RouteAdmin), s.handleGetAdminDashboard, http.MethodGet)
 		r.HandleFunc(RoutePattern(RouteAdminNeeds), s.handleGetAdminNeeds, http.MethodGet)
+		r.HandleFunc(RoutePattern(RouteAdminNeedExplorer), s.handleGetAdminNeedExplorer, http.MethodGet)
 		r.HandleFunc(RoutePattern(RouteAdminNeedReview), s.handleGetAdminNeedReview, http.MethodGet)
 		r.HandleFunc(RoutePattern(RouteAdminNeedModerate), s.handlePostAdminNeedModerate, http.MethodPost)
 		r.HandleFunc(RoutePattern(RouteAdminNeedDocument), s.handleGetAdminNeedDocument, http.MethodGet)

--- a/internal/server/templates/pages/admin-dashboard.html
+++ b/internal/server/templates/pages/admin-dashboard.html
@@ -9,6 +9,9 @@
       <a href="{{route "admin.needs" nil}}"
         class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">Open
         Needs Queue</a>
+      <a href="{{route "admin.need.explorer" nil}}"
+        class="ml-3 inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted">Open
+        Need Explorer</a>
     </div>
   </div>
 </section>

--- a/internal/server/templates/pages/admin-need-explorer.html
+++ b/internal/server/templates/pages/admin-need-explorer.html
@@ -6,7 +6,7 @@
       <div>
         <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Admin</p>
         <h1 class="mt-2 text-2xl font-semibold text-foreground">Need Explorer</h1>
-        <p class="mt-2 text-sm text-muted-foreground">Monitor post-approval need performance in one place.</p>
+        <p class="mt-2 text-sm text-muted-foreground">Explore all needs and monitor performance from a single admin surface.</p>
       </div>
       <div class="flex items-center gap-3">
         <a href="{{.QueueHref}}" class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted">Moderation Queue</a>
@@ -32,7 +32,8 @@
         </select>
       </div>
       <div class="md:self-end">
-        <button type="submit" class="inline-flex h-10 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white hover:bg-[color:var(--cj-primary)]/90">Apply</button>
+        <button type="submit"
+          class="inline-flex h-10 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white hover:bg-[color:var(--cj-primary)]/90">Apply</button>
       </div>
     </form>
 
@@ -93,7 +94,7 @@
     </div>
     {{else}}
       <p class="mt-6 text-sm text-muted-foreground">No needs found for this filter combination.</p>
-    {{end}}
+      {{end}}
   </div>
 </section>
 {{template "footer" .}}

--- a/internal/server/templates/pages/admin-need-explorer.html
+++ b/internal/server/templates/pages/admin-need-explorer.html
@@ -17,7 +17,8 @@
     {{if .StatusCards}}
     <div class="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {{range .StatusCards}}
-      <a href="{{.Href}}" class="rounded-xl border p-4 transition-colors {{if .IsActive}}border-[color:var(--cj-primary)] bg-[color:var(--cj-primary)]/5{{else}}border-border bg-background hover:bg-muted{{end}}">
+      <a href="{{.Href}}"
+        class="rounded-xl border p-4 transition-colors {{if .IsActive}}border-[color:var(--cj-primary)] bg-[color:var(--cj-primary)]/5{{else}}border-border bg-background hover:bg-muted{{end}}">
         <p class="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">{{.Label}}</p>
         <p class="mt-2 text-2xl font-semibold text-foreground">{{.Count}}</p>
       </a>
@@ -95,7 +96,11 @@
             <td class="py-3">
               <div class="flex items-center gap-3">
                 <a href="{{.ReviewHref}}" class="text-[color:var(--cj-primary)] hover:underline">Review</a>
+                {{if .CanViewDetail}}
                 <a href="{{.DetailHref}}" class="text-muted-foreground hover:text-foreground hover:underline">Detail</a>
+                {{else}}
+                <span class="text-xs text-muted-foreground">Detail unavailable</span>
+                {{end}}
               </div>
             </td>
           </tr>

--- a/internal/server/templates/pages/admin-need-explorer.html
+++ b/internal/server/templates/pages/admin-need-explorer.html
@@ -99,8 +99,8 @@
                 {{if .CanViewDetail}}
                 <a href="{{.DetailHref}}" class="text-muted-foreground hover:text-foreground hover:underline">Detail</a>
                 {{else}}
-                <span class="text-xs text-muted-foreground">Detail unavailable</span>
-                {{end}}
+                  <span class="text-xs text-muted-foreground">Detail unavailable</span>
+                  {{end}}
               </div>
             </td>
           </tr>

--- a/internal/server/templates/pages/admin-need-explorer.html
+++ b/internal/server/templates/pages/admin-need-explorer.html
@@ -1,0 +1,100 @@
+{{define "page.admin.need.explorer"}}
+{{template "header" .}}
+<section class="mx-auto w-full max-w-7xl px-4 py-12 md:px-6">
+  <div class="rounded-2xl border border-border bg-card p-6 shadow-sm">
+    <div class="flex flex-wrap items-start justify-between gap-4">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Admin</p>
+        <h1 class="mt-2 text-2xl font-semibold text-foreground">Need Explorer</h1>
+        <p class="mt-2 text-sm text-muted-foreground">Monitor post-approval need performance in one place.</p>
+      </div>
+      <div class="flex items-center gap-3">
+        <a href="{{.QueueHref}}" class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted">Moderation Queue</a>
+        <a href="{{.BackHref}}" class="text-sm text-muted-foreground hover:text-foreground">Back to Dashboard</a>
+      </div>
+    </div>
+
+    <form method="get" action="{{.FilterAction}}" class="mt-6 grid gap-3 rounded-xl border border-border bg-background p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+      <div>
+        <label class="mb-1 block text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground" for="status">Status</label>
+        <select id="status" name="status" class="h-10 w-full rounded-md border border-border bg-card px-3 text-sm text-foreground">
+          {{range .StatusOptions}}
+          <option value="{{.Value}}" {{if eq $.SelectedStatus .Value}}selected{{end}}>{{.Label}}</option>
+          {{end}}
+        </select>
+      </div>
+      <div>
+        <label class="mb-1 block text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground" for="sort">Sort</label>
+        <select id="sort" name="sort" class="h-10 w-full rounded-md border border-border bg-card px-3 text-sm text-foreground">
+          {{range .SortOptions}}
+          <option value="{{.Value}}" {{if eq $.SelectedSort .Value}}selected{{end}}>{{.Label}}</option>
+          {{end}}
+        </select>
+      </div>
+      <div class="md:self-end">
+        <button type="submit" class="inline-flex h-10 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white hover:bg-[color:var(--cj-primary)]/90">Apply</button>
+      </div>
+    </form>
+
+    <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+      <p>Showing {{.TotalNeeds}} needs • Filter: {{.CurrentStatusText}} • Page {{.Page}} of {{.TotalPages}}</p>
+      <div class="flex items-center gap-2">
+        {{if .PrevHref}}
+        <a href="{{.PrevHref}}" class="inline-flex h-8 items-center justify-center rounded-md border border-border px-3 text-xs font-medium text-foreground hover:bg-muted">Previous</a>
+        {{end}}
+        {{if .NextHref}}
+        <a href="{{.NextHref}}" class="inline-flex h-8 items-center justify-center rounded-md border border-border px-3 text-xs font-medium text-foreground hover:bg-muted">Next</a>
+        {{end}}
+      </div>
+    </div>
+
+    {{if .Needs}}
+    <div class="mt-6 overflow-x-auto">
+      <table class="min-w-full divide-y divide-border text-sm">
+        <thead>
+          <tr class="text-left text-muted-foreground">
+            <th class="py-2 pr-4">Need</th>
+            <th class="py-2 pr-4">Status</th>
+            <th class="py-2 pr-4">Raised / Goal</th>
+            <th class="py-2 pr-4">Funding</th>
+            <th class="py-2 pr-4">Activity</th>
+            <th class="py-2 pr-4">Published</th>
+            <th class="py-2 pr-4">Updated</th>
+            <th class="py-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border">
+          {{range .Needs}}
+          <tr>
+            <td class="py-3 pr-4 font-mono text-xs">{{.NeedID}}</td>
+            <td class="py-3 pr-4">{{.Status}}</td>
+            <td class="py-3 pr-4">${{div .AmountRaisedCents 100}} / ${{div .AmountNeededCents 100}}</td>
+            <td class="py-3 pr-4">
+              <div class="w-28">
+                <div class="h-2 rounded-full bg-muted">
+                  <div class="h-2 rounded-full bg-[color:var(--cj-primary)]" style="width: {{.FundingPercent}}%"></div>
+                </div>
+                <p class="mt-1 text-xs text-muted-foreground">{{.FundingPercent}}%</p>
+              </div>
+            </td>
+            <td class="py-3 pr-4">{{.ActivityLabel}}</td>
+            <td class="py-3 pr-4">{{.PublishedAt}}</td>
+            <td class="py-3 pr-4">{{.UpdatedAt}}</td>
+            <td class="py-3">
+              <div class="flex items-center gap-3">
+                <a href="{{.ReviewHref}}" class="text-[color:var(--cj-primary)] hover:underline">Review</a>
+                <a href="{{.DetailHref}}" class="text-muted-foreground hover:text-foreground hover:underline">Detail</a>
+              </div>
+            </td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{else}}
+      <p class="mt-6 text-sm text-muted-foreground">No needs found for this filter combination.</p>
+    {{end}}
+  </div>
+</section>
+{{template "footer" .}}
+{{end}}

--- a/internal/server/templates/pages/admin-need-explorer.html
+++ b/internal/server/templates/pages/admin-need-explorer.html
@@ -14,6 +14,17 @@
       </div>
     </div>
 
+    {{if .StatusCards}}
+    <div class="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {{range .StatusCards}}
+      <a href="{{.Href}}" class="rounded-xl border p-4 transition-colors {{if .IsActive}}border-[color:var(--cj-primary)] bg-[color:var(--cj-primary)]/5{{else}}border-border bg-background hover:bg-muted{{end}}">
+        <p class="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">{{.Label}}</p>
+        <p class="mt-2 text-2xl font-semibold text-foreground">{{.Count}}</p>
+      </a>
+      {{end}}
+    </div>
+    {{end}}
+
     <form method="get" action="{{.FilterAction}}" class="mt-6 grid gap-3 rounded-xl border border-border bg-background p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
       <div>
         <label class="mb-1 block text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground" for="status">Status</label>

--- a/internal/server/templates/pages/admin-needs.html
+++ b/internal/server/templates/pages/admin-needs.html
@@ -7,7 +7,10 @@
         <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Admin</p>
         <h1 class="mt-2 text-2xl font-semibold text-foreground">Needs Queue</h1>
       </div>
-      <a href="{{route "admin.dashboard" nil}}" class="text-sm text-muted-foreground hover:text-foreground">Back to Dashboard</a>
+      <div class="flex items-center gap-3">
+        <a href="{{route "admin.need.explorer" nil}}" class="text-sm text-[color:var(--cj-primary)] hover:underline">Need Explorer</a>
+        <a href="{{route "admin.dashboard" nil}}" class="text-sm text-muted-foreground hover:text-foreground">Back to Dashboard</a>
+      </div>
     </div>
 
     {{if .Needs}}

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -60,7 +60,7 @@ func (r *NeedRepository) Need(ctx context.Context, needID string) (*types.Need, 
 
 func (r *NeedRepository) BrowseNeeds(ctx context.Context) ([]*types.Need, error) {
 	query, args, err := psql().Select(needColumns...).From(needTableName).
-		Where(sq.NotEq{"status": types.NeedStatusDraft}).
+		Where(sq.Eq{"status": []types.NeedStatus{types.NeedStatusActive, types.NeedStatusFunded}}).
 		Where(sq.Eq{"deleted_at": nil}).
 		OrderBy("created_at desc").
 		ToSql()
@@ -408,6 +408,14 @@ func (r *NeedRepository) SetNeedStatusTx(ctx context.Context, tx pgx.Tx, needID 
 	return r.setNeedStatusWithExec(ctx, tx, needID, status)
 }
 
+func (r *NeedRepository) PublishNeed(ctx context.Context, needID string) error {
+	return r.publishNeedWithExec(ctx, r.pool, needID)
+}
+
+func (r *NeedRepository) PublishNeedTx(ctx context.Context, tx pgx.Tx, needID string) error {
+	return r.publishNeedWithExec(ctx, tx, needID)
+}
+
 func (r *NeedRepository) setNeedStatusWithExec(ctx context.Context, execer needExecer, needID string, status types.NeedStatus) error {
 	query, args, err := psql().
 		Update(needTableName).
@@ -421,6 +429,22 @@ func (r *NeedRepository) setNeedStatusWithExec(ctx context.Context, execer needE
 
 	_, err = execer.Exec(ctx, query, args...)
 	return utils.ErrorWrapOrNil(err, "failed to set need status")
+}
+
+func (r *NeedRepository) publishNeedWithExec(ctx context.Context, execer needExecer, needID string) error {
+	query, args, err := psql().
+		Update(needTableName).
+		Set("status", types.NeedStatusActive).
+		Set("published_at", sq.Expr("COALESCE(published_at, NOW())")).
+		Set("updated_at", time.Now()).
+		Where(sq.Eq{"id": needID}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to generate publish need query for need %s: %w", needID, err)
+	}
+
+	_, err = execer.Exec(ctx, query, args...)
+	return utils.ErrorWrapOrNil(err, "failed to publish need")
 }
 
 func (r *NeedRepository) SoftDeleteNeed(ctx context.Context, needID, actorUserID, reason string) error {

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -22,12 +22,6 @@ type NeedRepository struct {
 	pool *pgxpool.Pool
 }
 
-var adminExplorerStatuses = []types.NeedStatus{
-	types.NeedStatusApproved,
-	types.NeedStatusActive,
-	types.NeedStatusFunded,
-}
-
 type needExecer interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
@@ -157,8 +151,6 @@ func (r *NeedRepository) AdminExplorerNeedsPage(ctx context.Context, page, pageS
 
 	if statusFilter != nil {
 		queryBuilder = queryBuilder.Where(sq.Eq{"status": *statusFilter})
-	} else {
-		queryBuilder = queryBuilder.Where(sq.Eq{"status": adminExplorerStatuses})
 	}
 
 	switch sortBy {
@@ -202,8 +194,6 @@ func (r *NeedRepository) AdminExplorerNeedsCount(ctx context.Context, statusFilt
 
 	if statusFilter != nil {
 		queryBuilder = queryBuilder.Where(sq.Eq{"status": *statusFilter})
-	} else {
-		queryBuilder = queryBuilder.Where(sq.Eq{"status": adminExplorerStatuses})
 	}
 
 	query, args, err := queryBuilder.ToSql()

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -22,6 +22,12 @@ type NeedRepository struct {
 	pool *pgxpool.Pool
 }
 
+var adminExplorerStatuses = []types.NeedStatus{
+	types.NeedStatusApproved,
+	types.NeedStatusActive,
+	types.NeedStatusFunded,
+}
+
 type needExecer interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
@@ -131,6 +137,83 @@ func (r *NeedRepository) ModerationQueueNeedsCount(ctx context.Context) (int, er
 	var total int
 	if err := r.pool.QueryRow(ctx, query, args...).Scan(&total); err != nil {
 		return 0, fmt.Errorf("failed to count moderation queue needs: %w", err)
+	}
+
+	return total, nil
+}
+
+func (r *NeedRepository) AdminExplorerNeedsPage(ctx context.Context, page, pageSize int, statusFilter *types.NeedStatus, sortBy string) ([]*types.Need, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+
+	offset := uint64((page - 1) * pageSize)
+
+	queryBuilder := psql().Select(needColumns...).From(needTableName).
+		Where(sq.Eq{"deleted_at": nil})
+
+	if statusFilter != nil {
+		queryBuilder = queryBuilder.Where(sq.Eq{"status": *statusFilter})
+	} else {
+		queryBuilder = queryBuilder.Where(sq.Eq{"status": adminExplorerStatuses})
+	}
+
+	switch sortBy {
+	case "updated_asc":
+		queryBuilder = queryBuilder.OrderBy("updated_at asc")
+	case "raised_desc":
+		queryBuilder = queryBuilder.OrderBy("amount_raised_cents desc", "updated_at desc")
+	case "needed_desc":
+		queryBuilder = queryBuilder.OrderBy("amount_needed_cents desc", "updated_at desc")
+	case "progress_desc":
+		queryBuilder = queryBuilder.OrderBy("CASE WHEN amount_needed_cents > 0 THEN (amount_raised_cents::float / amount_needed_cents::float) ELSE 0 END desc", "updated_at desc")
+	default:
+		queryBuilder = queryBuilder.OrderBy("updated_at desc")
+	}
+
+	query, args, err := queryBuilder.
+		Limit(uint64(pageSize)).
+		Offset(offset).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate admin explorer needs query: %w", err)
+	}
+
+	needs := make([]*types.Need, 0)
+	err = pgxscan.Select(ctx, r.pool, &needs, query, args...)
+	if err != nil {
+		if pgxscan.NotFound(err) {
+			return needs, nil
+		}
+		return nil, fmt.Errorf("failed to fetch admin explorer needs: %w", err)
+	}
+
+	return needs, nil
+}
+
+func (r *NeedRepository) AdminExplorerNeedsCount(ctx context.Context, statusFilter *types.NeedStatus) (int, error) {
+	queryBuilder := psql().
+		Select("COUNT(*)").
+		From(needTableName).
+		Where(sq.Eq{"deleted_at": nil})
+
+	if statusFilter != nil {
+		queryBuilder = queryBuilder.Where(sq.Eq{"status": *statusFilter})
+	} else {
+		queryBuilder = queryBuilder.Where(sq.Eq{"status": adminExplorerStatuses})
+	}
+
+	query, args, err := queryBuilder.ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("failed to generate admin explorer needs count query: %w", err)
+	}
+
+	var total int
+	if err := r.pool.QueryRow(ctx, query, args...).Scan(&total); err != nil {
+		return 0, fmt.Errorf("failed to count admin explorer needs: %w", err)
 	}
 
 	return total, nil

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -155,15 +155,15 @@ func (r *NeedRepository) AdminExplorerNeedsPage(ctx context.Context, page, pageS
 
 	switch sortBy {
 	case "updated_asc":
-		queryBuilder = queryBuilder.OrderBy("updated_at asc")
+		queryBuilder = queryBuilder.OrderBy("updated_at asc", "id asc")
 	case "raised_desc":
-		queryBuilder = queryBuilder.OrderBy("amount_raised_cents desc", "updated_at desc")
+		queryBuilder = queryBuilder.OrderBy("amount_raised_cents desc", "updated_at desc", "id asc")
 	case "needed_desc":
-		queryBuilder = queryBuilder.OrderBy("amount_needed_cents desc", "updated_at desc")
+		queryBuilder = queryBuilder.OrderBy("amount_needed_cents desc", "updated_at desc", "id asc")
 	case "progress_desc":
-		queryBuilder = queryBuilder.OrderBy("CASE WHEN amount_needed_cents > 0 THEN (amount_raised_cents::float / amount_needed_cents::float) ELSE 0 END desc", "updated_at desc")
+		queryBuilder = queryBuilder.OrderBy("CASE WHEN amount_needed_cents > 0 THEN (amount_raised_cents::float / amount_needed_cents::float) ELSE 0 END desc", "updated_at desc", "id asc")
 	default:
-		queryBuilder = queryBuilder.OrderBy("updated_at desc")
+		queryBuilder = queryBuilder.OrderBy("updated_at desc", "id asc")
 	}
 
 	query, args, err := queryBuilder.

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -209,6 +209,38 @@ func (r *NeedRepository) AdminExplorerNeedsCount(ctx context.Context, statusFilt
 	return total, nil
 }
 
+func (r *NeedRepository) AdminExplorerNeedsCountByStatus(ctx context.Context) (map[types.NeedStatus]int, error) {
+	query, args, err := psql().
+		Select("status", "COUNT(*)").
+		From(needTableName).
+		Where(sq.Eq{"deleted_at": nil}).
+		GroupBy("status").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate admin explorer grouped count query: %w", err)
+	}
+
+	type statusCountRow struct {
+		Status types.NeedStatus `db:"status"`
+		Count  int              `db:"count"`
+	}
+
+	rows := make([]statusCountRow, 0)
+	if err := pgxscan.Select(ctx, r.pool, &rows, query, args...); err != nil {
+		if pgxscan.NotFound(err) {
+			return map[types.NeedStatus]int{}, nil
+		}
+		return nil, fmt.Errorf("failed to fetch admin explorer grouped counts: %w", err)
+	}
+
+	counts := make(map[types.NeedStatus]int, len(rows))
+	for _, row := range rows {
+		counts[row.Status] = row.Count
+	}
+
+	return counts, nil
+}
+
 func (r *NeedRepository) LatestNeeds(ctx context.Context, limit int) ([]*types.Need, error) {
 	if limit <= 0 {
 		limit = 5

--- a/migrations/needs.pg.hcl
+++ b/migrations/needs.pg.hcl
@@ -57,7 +57,7 @@ table "needs" {
     type    = text
     null    = false
     default = "DRAFT"
-    comment = "DRAFT, SUBMITTED, READY_FOR_REVIEW, UNDER_REVIEW, CHANGES_REQUESTED, APPROVED, REJECTED, ACTIVE, FUNDED, CLOSED"
+    comment = "DRAFT, SUBMITTED, READY_FOR_REVIEW, UNDER_REVIEW, CHANGES_REQUESTED, REJECTED, ACTIVE, FUNDED, CLOSED"
   }
 
   column "verified_at" {

--- a/pkg/types/need.go
+++ b/pkg/types/need.go
@@ -12,7 +12,6 @@ const (
 	NeedStatusReadyForReview   NeedStatus = "READY_FOR_REVIEW"
 	NeedStatusUnderReview      NeedStatus = "UNDER_REVIEW"
 	NeedStatusChangesRequested NeedStatus = "CHANGES_REQUESTED"
-	NeedStatusApproved         NeedStatus = "APPROVED"
 	NeedStatusRejected         NeedStatus = "REJECTED"
 	NeedStatusActive           NeedStatus = "ACTIVE"
 	NeedStatusFunded           NeedStatus = "FUNDED"

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -410,6 +410,7 @@ type AdminNeedQueueItem struct {
 type AdminNeedExplorerPageData struct {
 	BasePageData
 	Needs             []*AdminNeedExplorerItem
+	StatusCards       []*AdminNeedStatusCard
 	Page              int
 	PageSize          int
 	TotalNeeds        int
@@ -424,6 +425,14 @@ type AdminNeedExplorerPageData struct {
 	BackHref          string
 	QueueHref         string
 	CurrentStatusText string
+}
+
+type AdminNeedStatusCard struct {
+	Status  NeedStatus
+	Label   string
+	Count   int
+	Href    string
+	IsActive bool
 }
 
 type AdminExplorerOption struct {

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -407,6 +407,43 @@ type AdminNeedQueueItem struct {
 	ReviewHref  string
 }
 
+type AdminNeedExplorerPageData struct {
+	BasePageData
+	Needs             []*AdminNeedExplorerItem
+	Page              int
+	PageSize          int
+	TotalNeeds        int
+	TotalPages        int
+	PrevHref          string
+	NextHref          string
+	SelectedStatus    string
+	SelectedSort      string
+	FilterAction      string
+	StatusOptions     []AdminExplorerOption
+	SortOptions       []AdminExplorerOption
+	BackHref          string
+	QueueHref         string
+	CurrentStatusText string
+}
+
+type AdminExplorerOption struct {
+	Value string
+	Label string
+}
+
+type AdminNeedExplorerItem struct {
+	NeedID            string
+	Status            NeedStatus
+	AmountRaisedCents int
+	AmountNeededCents int
+	FundingPercent    int
+	ActivityLabel     string
+	UpdatedAt         string
+	PublishedAt       string
+	ReviewHref        string
+	DetailHref        string
+}
+
 type AdminNeedReviewPageData struct {
 	BasePageData
 	Need                *Need

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -451,6 +451,7 @@ type AdminNeedExplorerItem struct {
 	PublishedAt       string
 	ReviewHref        string
 	DetailHref        string
+	CanViewDetail     bool
 }
 
 type AdminNeedReviewPageData struct {


### PR DESCRIPTION
## Summary
- Adds an Admin Need Explorer page under Admin for operational monitoring across all non-deleted needs.
- Adds status summary cards at the top of the explorer with per-status counts and quick filtering.
- Implements status filter/sort normalization and deterministic pagination ordering.
- Applies finalized donation totals in explorer metrics and reuses shared funding percentage helper for consistency.
- Restricts public Detail links in explorer to public-facing statuses only.
- Simplifies lifecycle by removing APPROVED as a persisted need status; approval remains a moderation action and publish transitions to ACTIVE.
- Fixes public browse visibility to only show ACTIVE and FUNDED needs.

## Included
- Route + handler: admin.need.explorer
- Repository support: explorer page/count/count-by-status + stable sort tie-breakers
- New explorer template and navigation links from dashboard/queue
- Lifecycle cleanup: removed NeedStatusApproved usages and
## Summary
- Adds an- Approval flow: approve now publishes (UNDER_REVIEW -> ACTIVE)

## Testing
- go test -count=1 ./internal/server/... ./internal/store/... ./internal/seed/... ./pkg/...

## References
- Closes #24
