### PR TITLE
Design refresh: gold/midnight/cream palette + guidelines page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,8 @@ docs/                 # ADRs, design documents, QA plans
 - **Logging:** `github.com/sirupsen/logrus` (structured JSON)
 - **CSRF:** All state-mutating routes use `gorilla/csrf` except `/webhooks/stripe` (uses Stripe signature verification)
 - **Templates:** Embedded via `//go:embed` and served SSR — no frontend framework
+- **CSS:** Tailwind via CDN with custom design tokens in `internal/server/static/tokens.css`. Colors defined as CSS variables **cannot** be used as bare Tailwind utility classes (e.g. `bg-midnight` won't work). Use the bracket syntax instead: `bg-[#0D1B2A]` or `text-[color:var(--cj-secondary)]`. The existing `[color:var(--cj-*)]` pattern is the established convention.
+- **Design tokens:** Palette is gold (`#C9A84C`) + midnight (`#0D1B2A`) + cream (`#FAF7F0`) + warm ink text. Fonts are Jost (body) + Cormorant Garamond (headings/display).
 - **Tests:** Standard library `testing` only — no testify or gomock
 - **Formatting:** `go fmt` (no golangci-lint configured)
 

--- a/internal/server/guidelines.go
+++ b/internal/server/guidelines.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"christjesus/pkg/types"
+	"net/http"
+)
+
+func (s *Service) handleGetGuidelines(w http.ResponseWriter, r *http.Request) {
+	data := &types.BasePageData{Title: "Community Guidelines"}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.renderTemplate(w, r, "page.guidelines", data); err != nil {
+		s.logger.WithError(err).Error("failed to render guidelines page")
+		s.internalServerError(w)
+		return
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -187,6 +187,7 @@ func (s *Service) buildRouter(r *flow.Mux, csrfKey []byte) {
 		r.HandleFunc(RoutePattern(RouteCategories), s.handleCategories, http.MethodGet)
 		r.HandleFunc(RoutePattern(RouteCategoryNeeds), s.handleCategoryNeeds, http.MethodGet)
 		r.HandleFunc(RoutePattern(RouteNeedDetail), s.handleNeedDetail, http.MethodGet)
+		r.HandleFunc(RoutePattern(RouteGuidelines), s.handleGetGuidelines, http.MethodGet)
 
 		r.Group(func(r *flow.Mux) {
 			r.Use(s.RequireAuth)

--- a/internal/server/static/tokens.css
+++ b/internal/server/static/tokens.css
@@ -1,43 +1,60 @@
 :root {
   --radius: 0.625rem;
-  --background: #ffffff;
-  --foreground: #0f172a;
+
+  /* Core palette — refreshed from design mockup */
+  --gold: #C9A84C;
+  --gold-light: #E8C97A;
+  --gold-pale: #F5EDDA;
+  --midnight: #0D1B2A;
+  --midnight-mid: #1C2E42;
+  --ink: #1A1610;
+  --ink-soft: #3D3528;
+  --cream: #FAF7F0;
+  --rule: rgba(201, 168, 76, 0.25);
+
+  /* Semantic mappings */
+  --background: #FAF7F0;
+  --foreground: #2E2719;
   --card: #ffffff;
-  --card-foreground: #0f172a;
+  --card-foreground: var(--ink);
   --popover: #ffffff;
-  --popover-foreground: #0f172a;
-  --primary: #1b3a52;
+  --popover-foreground: var(--ink);
+  --primary: var(--midnight);
   --primary-foreground: #f8fafc;
-  --secondary: #e6a944;
-  --secondary-foreground: #0f172a;
-  --muted: #f1f5f9;
-  --muted-foreground: #64748b;
-  --accent: #4a9b9f;
-  --accent-foreground: #0f172a;
+  --secondary: var(--gold);
+  --secondary-foreground: var(--midnight);
+  --muted: var(--gold-pale);
+  --muted-foreground: var(--ink-soft);
+  --accent: var(--gold);
+  --accent-foreground: var(--midnight);
   --destructive: #ef4444;
-  --border: #e2e8f0;
-  --input: #e2e8f0;
-  --ring: #94a3b8;
-  --sidebar: #f8fafc;
-  --sidebar-foreground: #0f172a;
-  --sidebar-primary: #1b3a52;
+  --border: var(--rule);
+  --input: rgba(201, 168, 76, 0.25);
+  --ring: var(--gold);
+  --sidebar: var(--cream);
+  --sidebar-foreground: var(--ink);
+  --sidebar-primary: var(--midnight);
   --sidebar-primary-foreground: #f8fafc;
-  --sidebar-accent: #e2e8f0;
-  --sidebar-accent-foreground: #0f172a;
-  --sidebar-border: #e2e8f0;
-  --sidebar-ring: #94a3b8;
+  --sidebar-accent: var(--gold-pale);
+  --sidebar-accent-foreground: var(--ink);
+  --sidebar-border: var(--rule);
+  --sidebar-ring: var(--gold);
 
-  --cj-success: #10b981;
+  /* Status colors */
+  --cj-success: #5C9E70;
   --cj-warning: #f59e0b;
-  --cj-error: #ef4444;
+  --cj-error: #A85252;
   --cj-info: #3b82f6;
-  --cj-primary: #1b3a52;
-  --cj-secondary: #e6a944;
-  --cj-accent: #4a9b9f;
 
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-  --font-display: "Poppins", ui-sans-serif, system-ui, sans-serif;
-  --font-accent: "Montserrat", ui-sans-serif, system-ui, sans-serif;
+  /* Shortcuts used in Tailwind classes */
+  --cj-primary: var(--midnight);
+  --cj-secondary: var(--gold);
+  --cj-accent: var(--gold-light);
+
+  /* Typography */
+  --font-sans: "Jost", ui-sans-serif, system-ui, sans-serif;
+  --font-display: "Cormorant Garamond", "Georgia", serif;
+  --font-accent: "Jost", ui-sans-serif, system-ui, sans-serif;
 }
 
 .dark {
@@ -103,7 +120,7 @@ h6 {
 }
 
 .btn-primary:hover {
-  background-color: #152e41;
+  background-color: var(--midnight-mid);
 }
 
 .btn-outline {
@@ -140,5 +157,5 @@ h6 {
 
 /* Gradient Backgrounds */
 .bg-gradient-hero {
-  background: linear-gradient(to bottom right, #ffffff, #f8fafc, #fffbeb);
+  background: linear-gradient(to bottom right, var(--cream), #f5f0e8, var(--gold-pale));
 }

--- a/internal/server/templates/components/footer.html
+++ b/internal/server/templates/components/footer.html
@@ -1,17 +1,16 @@
 {{define "component.footer"}}
-<footer class="mt-10 border-t border-border bg-white">
-  <div class="mx-auto w-full max-w-6xl px-4 py-10 md:px-6">
-    <div class="flex flex-col items-start justify-between gap-6 md:flex-row md:items-center">
-      <div>
-        <p class="text-lg font-semibold text-[color:var(--cj-primary)]">ChristJesus.app</p>
-        <p class="mt-2 max-w-sm text-sm text-muted-foreground">Connecting verified needs with sponsors and organizations ready to serve.</p>
+<footer class="mt-10 border-t border-[rgba(201,168,76,0.2)] bg-[#0D1B2A]">
+  <div class="mx-auto w-full max-w-6xl px-4 py-12 md:px-6">
+    <div class="flex flex-col items-center text-center">
+      <p class="font-display text-xl font-semibold text-white">Christ<span class="text-[color:var(--cj-secondary)]">Jesus</span>.app</p>
+      <p class="mt-1 text-xs font-light uppercase tracking-widest text-[rgba(255,255,255,0.35)]">Bearing one another's burdens</p>
+      <div class="mt-6 flex flex-wrap justify-center gap-6 text-xs text-[rgba(255,255,255,0.4)]">
+        <a href="{{route "home" nil}}" class="tracking-wide transition-colors hover:text-[color:var(--cj-secondary)]">Home</a>
+        <a href="{{route "browse" nil}}" class="tracking-wide transition-colors hover:text-[color:var(--cj-secondary)]">Browse Needs</a>
+        <a href="{{route "guidelines" nil}}" class="tracking-wide transition-colors hover:text-[color:var(--cj-secondary)]">Guidelines</a>
       </div>
-      <div class="flex flex-wrap gap-4 text-sm text-muted-foreground">
-        <a href="{{route "home" nil}}" class="transition-colors hover:text-foreground">Home</a>
-        <a href="#forms" class="transition-colors hover:text-foreground">Forms</a>
-      </div>
+      <div class="mt-6 text-[11px] text-[rgba(255,255,255,0.2)]">&copy; 2026 ChristJesus.app &middot; Charlotte, NC &middot; All rights reserved.</div>
     </div>
-    <div class="mt-8 border-t border-border pt-6 text-xs text-muted-foreground">© 2026 ChristJesus.app. All rights reserved.</div>
   </div>
 </footer>
 {{end}}

--- a/internal/server/templates/components/nav.html
+++ b/internal/server/templates/components/nav.html
@@ -1,43 +1,37 @@
 {{define "component.nav"}}
-<header class="border-b border-border bg-white/80 backdrop-blur">
+<header class="border-b border-[color:var(--border)] bg-[color:var(--cream)]/80 backdrop-blur">
   <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 md:px-6">
     <a href="{{route "home" nil}}" class="flex items-center gap-2">
-      <span class="text-xl font-semibold text-[color:var(--cj-primary)]">ChristJesus.app</span>
+      <span class="font-display text-2xl font-semibold text-[#0D1B2A]">Christ<span class="text-[color:var(--cj-secondary)]">Jesus</span>.app</span>
     </a>
-    <nav class="hidden items-center gap-6 text-sm text-muted-foreground md:flex">
-      <a href="{{route "browse" nil}}" class="transition-colors hover:text-foreground">Browse Needs</a>
-      <a href="{{route "categories" nil}}" class="transition-colors hover:text-foreground">Categories</a>
-      <a href="{{route "map" nil}}" class="transition-colors hover:text-foreground">Map</a>
-      <a href="{{route "guidelines" nil}}" class="transition-colors hover:text-foreground">Guidelines</a>
-      {{if .Navbar.IsAdmin}}<a href="{{route "admin.dashboard" nil}}" class="transition-colors hover:text-foreground">Admin</a>{{end}}
+    <nav class="hidden items-center gap-6 text-sm text-[color:var(--ink-soft)] md:flex">
+      <a href="{{route "browse" nil}}" class="transition-colors hover:text-[color:var(--cj-secondary)]">Browse Needs</a>
+      <a href="{{route "categories" nil}}" class="transition-colors hover:text-[color:var(--cj-secondary)]">Categories</a>
+      <a href="{{route "map" nil}}" class="transition-colors hover:text-[color:var(--cj-secondary)]">Map</a>
+      <a href="{{route "guidelines" nil}}" class="transition-colors hover:text-[color:var(--cj-secondary)]">Guidelines</a>
+      {{if .Navbar.IsAdmin}}<a href="{{route "admin.dashboard" nil}}" class="transition-colors hover:text-[color:var(--cj-secondary)]">Admin</a>{{end}}
     </nav>
     <div class="flex items-center gap-3">
       {{if .Navbar.IsAuthenticated}}
       <div class="hidden items-center gap-3 md:flex">
-        <span class="text-sm text-muted-foreground">Welcome, {{.Navbar.UserName}}</span>
+        <span class="text-sm text-[color:var(--ink-soft)]">Welcome, {{.Navbar.UserName}}</span>
         <details data-profile-menu class="group relative">
-          <summary class="flex h-9 w-9 cursor-pointer list-none items-center justify-center overflow-hidden rounded-full border border-border bg-muted">
+          <summary class="flex h-9 w-9 cursor-pointer list-none items-center justify-center overflow-hidden rounded-full border border-[color:var(--border)] bg-[color:var(--gold-pale)]">
             <img src="{{.Navbar.AvatarURL}}" alt="Profile" class="h-full w-full object-cover" />
           </summary>
-          <div class="absolute right-0 z-20 mt-2 w-44 rounded-md border border-border bg-[color:var(--popover)] p-1 opacity-100 shadow-lg">
-            <a href="{{route "profile" nil}}" class="block rounded px-3 py-2 text-sm text-foreground transition-colors hover:bg-muted">Profile</a>
-            <div class="my-1 border-t border-border"></div>
+          <div class="absolute right-0 z-20 mt-2 w-44 rounded-md border border-[color:var(--border)] bg-[color:var(--cream)] p-1 shadow-lg">
+            <a href="{{route "profile" nil}}" class="block rounded px-3 py-2 text-sm text-foreground transition-colors hover:bg-[color:var(--gold-pale)]">Profile</a>
+            <div class="my-1 border-t border-[color:var(--border)]"></div>
             <form method="POST" action="{{route "logout" nil}}">
               {{.CSRFField}}
-              <button type="submit" class="block w-full rounded px-3 py-2 text-left text-sm text-foreground transition-colors hover:bg-muted">Log Out</button>
+              <button type="submit" class="block w-full rounded px-3 py-2 text-left text-sm text-foreground transition-colors hover:bg-[color:var(--gold-pale)]">Log Out</button>
             </form>
           </div>
         </details>
       </div>
       {{else}}
-        <a href="{{route "login" nil}}" class="hidden text-sm text-muted-foreground transition-colors hover:text-foreground md:inline-flex">Sign In</a>
+        <a href="{{route "login" nil}}" class="hidden text-sm text-[color:var(--ink-soft)] transition-colors hover:text-[color:var(--cj-secondary)] md:inline-flex">Sign In</a>
         {{end}}
-
-        <!--
-      <a href="{{route "share" nil}}"
-        class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">Share
-        Your Story</a>
-      -->
     </div>
   </div>
 </header>

--- a/internal/server/templates/layout.html
+++ b/internal/server/templates/layout.html
@@ -10,7 +10,7 @@
     </title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600;700&family=Montserrat:wght@500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400&family=Jost:wght@300;400;500;600&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/static/tokens.css" />
     <script>
       tailwind.config = {
@@ -31,6 +31,18 @@
               'accent-foreground': 'var(--accent-foreground)',
               border: 'var(--border)',
               destructive: 'var(--destructive)',
+              gold: 'var(--gold)',
+              'gold-light': 'var(--gold-light)',
+              'gold-pale': 'var(--gold-pale)',
+              midnight: 'var(--midnight)',
+              'midnight-mid': 'var(--midnight-mid)',
+              ink: 'var(--ink)',
+              'ink-soft': 'var(--ink-soft)',
+              cream: 'var(--cream)',
+            },
+            fontFamily: {
+              sans: ['Jost', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+              display: ['Cormorant Garamond', 'Georgia', 'serif'],
             },
           },
         },
@@ -64,10 +76,10 @@
     </style>
   </head>
 
-  <body class="bg-background text-foreground min-h-screen">
-    <div class="min-h-screen bg-background text-foreground">
+  <body class="bg-[#FAF7F0] text-foreground min-h-screen">
+    <div class="flex min-h-screen flex-col bg-[#FAF7F0] text-foreground">
       {{template "component.nav" .}}
-      <main>
+      <main class="flex-1">
         {{end}}
 
         {{define "footer"}}

--- a/internal/server/templates/pages/guidelines.html
+++ b/internal/server/templates/pages/guidelines.html
@@ -1,0 +1,438 @@
+{{define "page.guidelines"}}
+{{template "header" .}}
+
+<!-- HERO -->
+<section class="relative overflow-hidden bg-[#0D1B2A] px-6 py-24 text-center md:py-32">
+  <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_-10%,rgba(201,168,76,0.18)_0%,transparent_70%)]"></div>
+  <div class="relative mx-auto max-w-3xl">
+    <p class="mb-7 flex items-center justify-center gap-4 text-xs font-medium uppercase tracking-[0.35em] text-[color:var(--cj-secondary)]">
+      <span class="block h-px w-10 bg-[color:var(--cj-secondary)] opacity-50"></span>
+      ChristJesus.app
+      <span class="block h-px w-10 bg-[color:var(--cj-secondary)] opacity-50"></span>
+    </p>
+    <h1 class="font-display text-5xl font-light leading-tight text-white md:text-7xl">Community<br><em class="italic text-[color:var(--cj-accent)]">Guidelines</em></h1>
+    <p class="mx-auto mt-6 max-w-md text-sm font-light leading-relaxed text-white/55 tracking-wide">A platform built on the love of Christ, the integrity of the Church, and the dignity of every person in need.</p>
+  </div>
+  <div class="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-[color:var(--cj-secondary)] to-transparent"></div>
+</section>
+
+<!-- VERSE BAND -->
+<div class="bg-[color:var(--cj-secondary)] px-6 py-5 text-center">
+  <p class="font-display text-base font-normal italic text-[#0D1B2A]">"Carry each other's burdens, and in this way you will fulfill the law of Christ." &nbsp;<cite class="not-italic text-xs font-semibold tracking-wider">— Galatians 6:2</cite></p>
+</div>
+
+<!-- MAIN CONTENT -->
+<div class="mx-auto max-w-[820px] px-6 py-20">
+
+  <!-- TABLE OF CONTENTS -->
+  <nav class="relative mb-16 overflow-hidden rounded bg-[#0D1B2A] px-10 py-9" aria-label="Table of Contents">
+    <div class="absolute left-0 top-0 h-full w-[3px] bg-[color:var(--cj-secondary)]"></div>
+    <p class="mb-5 font-display text-[11px] font-semibold uppercase tracking-[0.25em] text-[color:var(--cj-secondary)]">In This Document</p>
+    <ol class="grid list-none grid-cols-1 gap-x-8 gap-y-2.5 sm:grid-cols-2">
+      <li><a href="#mission" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">01 &nbsp; Our Mission &amp; Foundation</a></li>
+      <li><a href="#who" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">02 &nbsp; Who Can Use This Platform</a></li>
+      <li><a href="#needs" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">03 &nbsp; What Qualifies as a Need</a></li>
+      <li><a href="#verification" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">04 &nbsp; Verification &amp; Accountability</a></li>
+      <li><a href="#sponsors" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">05 &nbsp; Sponsors &amp; Donors</a></li>
+      <li><a href="#funds" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">06 &nbsp; How Funds Are Handled</a></li>
+      <li><a href="#conduct" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">07 &nbsp; Community Conduct</a></li>
+      <li><a href="#prohibited" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">08 &nbsp; Prohibited Uses</a></li>
+      <li><a href="#consequences" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">09 &nbsp; Violations &amp; Consequences</a></li>
+      <li><a href="#contact" class="text-[13px] font-normal text-white/65 transition-colors hover:text-[color:var(--cj-accent)]">10 &nbsp; Questions &amp; Disputes</a></li>
+    </ol>
+  </nav>
+
+  <!-- 01 MISSION -->
+  <section id="mission" data-reveal class="mb-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">01</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Foundation</span>
+        Our Mission
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">ChristJesus.app exists to be the Body of Christ in action — a living expression of the Church's call to care for one another. We are not a general crowdfunding platform. We are a covenant community where <strong class="font-semibold text-[color:var(--ink)]">verified needs meet generous hearts</strong>, guided by Scripture, accountability, and love.</p>
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Everything on this platform — from how needs are posted to how funds are distributed — is designed to honor God, protect the vulnerable, and build trust within the Body of Christ.</p>
+
+      <!-- PILLARS -->
+      <div class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div class="rounded bg-[#0D1B2A] p-7 text-center">
+          <span class="mb-3.5 block text-2xl">✝</span>
+          <p class="mb-2 font-display text-xl font-semibold text-[color:var(--cj-accent)]">Christ-Centered</p>
+          <p class="text-xs font-light leading-relaxed text-white/50">Every feature, every policy, every decision flows from the example of Jesus and the witness of Scripture.</p>
+        </div>
+        <div class="rounded bg-[#0D1B2A] p-7 text-center">
+          <span class="mb-3.5 block text-2xl">⚖</span>
+          <p class="mb-2 font-display text-xl font-semibold text-[color:var(--cj-accent)]">Accountable</p>
+          <p class="text-xs font-light leading-relaxed text-white/50">Needs are verified. Funds are tracked. Sponsors are supported by case managers. Nothing is anonymous or unchecked.</p>
+        </div>
+        <div class="rounded bg-[#0D1B2A] p-7 text-center">
+          <span class="mb-3.5 block text-2xl">🤝</span>
+          <p class="mb-2 font-display text-xl font-semibold text-[color:var(--cj-accent)]">Relational</p>
+          <p class="text-xs font-light leading-relaxed text-white/50">This is not a transaction. It is a relationship between those in need and those called to give.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 02 WHO -->
+  <section id="who" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">02</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Eligibility</span>
+        Who Can Use This Platform
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">ChristJesus.app serves three primary groups within the Body of Christ:</p>
+      <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div class="relative rounded border border-[rgba(201,168,76,0.2)] bg-white p-6">
+          <div class="absolute left-0 top-0 h-[3px] w-full rounded-t bg-gradient-to-r from-[#5C9E70] to-[#7DC893]"></div>
+          <p class="mb-3.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#5C9E70]">Those in Need</p>
+          <ul class="space-y-1.5">
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Individuals or families facing a verified, genuine hardship</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Church members referred by a pastor or ministry leader</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Community members connected through a partnering organization</li>
+          </ul>
+        </div>
+        <div class="relative rounded border border-[rgba(201,168,76,0.2)] bg-white p-6">
+          <div class="absolute left-0 top-0 h-[3px] w-full rounded-t bg-gradient-to-r from-[#5C9E70] to-[#7DC893]"></div>
+          <p class="mb-3.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#5C9E70]">Sponsors &amp; Donors</p>
+          <ul class="space-y-1.5">
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Individual Christians giving in response to a specific need</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Churches or ministries pooling giving toward a cause</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Organizations sponsoring multiple recipients over time</li>
+          </ul>
+        </div>
+        <div class="relative rounded border border-[rgba(201,168,76,0.2)] bg-white p-6">
+          <div class="absolute left-0 top-0 h-[3px] w-full rounded-t bg-gradient-to-r from-[#5C9E70] to-[#7DC893]"></div>
+          <p class="mb-3.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#5C9E70]">Case Managers</p>
+          <ul class="space-y-1.5">
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Pastors or ministry staff verifying and shepherding those in need</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Nonprofit organizations with verified status on platform</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Approved community advocates in the Charlotte area and beyond</li>
+          </ul>
+        </div>
+      </div>
+      <p class="mt-6 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">All users must agree to these Community Guidelines and our Terms of Service to participate. Creating an account constitutes agreement with the spirit and letter of these policies.</p>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 03 NEEDS -->
+  <section id="needs" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">03</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Submissions</span>
+        What Qualifies as a Need
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Not every financial hardship qualifies for this platform. ChristJesus.app is designed to address <strong class="font-semibold text-[color:var(--ink)]">acute, verifiable, and real-world needs</strong> — the kind that the early Church would have recognized and responded to immediately.</p>
+
+      <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <!-- Eligible -->
+        <div class="relative rounded border border-[rgba(201,168,76,0.2)] bg-white p-6">
+          <div class="absolute left-0 top-0 h-[3px] w-full rounded-t bg-gradient-to-r from-[#5C9E70] to-[#7DC893]"></div>
+          <p class="mb-3.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#5C9E70]">Eligible Need Categories</p>
+          <ul class="space-y-1.5">
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Utilities shutoff or at-risk of disconnection</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Housing: eviction prevention, emergency shelter deposits</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Food insecurity for individuals or families</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Medical bills, prescriptions, or emergency care costs</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Funeral and burial assistance</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Transportation needs tied to work or care</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Emergency childcare or family crisis situations</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Disaster relief (fire, flood, natural disaster)</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#5C9E70]">✦</span> Clothing or essentials for vulnerable individuals</li>
+          </ul>
+        </div>
+        <!-- Not Eligible -->
+        <div class="relative rounded border border-[rgba(201,168,76,0.2)] bg-white p-6">
+          <div class="absolute left-0 top-0 h-[3px] w-full rounded-t bg-gradient-to-r from-[#A85252] to-[#C97070]"></div>
+          <p class="mb-3.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#A85252]">Not Eligible</p>
+          <ul class="space-y-1.5">
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Business investments or startup capital</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Vacation, entertainment, or luxury expenses</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Student loans or personal debt relief (general)</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Legal fees unrelated to family protection</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Political campaigns or advocacy funding</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Needs without verifiable documentation</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Duplicate campaigns for the same need</li>
+            <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Needs on behalf of unverified third parties</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mt-7 rounded-r border-l-[3px] border-[color:var(--cj-secondary)] bg-[color:var(--gold-pale)] px-6 py-5">
+        <p class="font-display text-lg italic leading-relaxed text-[color:var(--ink)]">"If anyone has material possessions and sees a brother or sister in need but has no pity on them, how can the love of God be in that person?" — 1 John 3:17</p>
+      </div>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 04 VERIFICATION -->
+  <section id="verification" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">04</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Integrity</span>
+        Verification &amp; Accountability
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-6 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Integrity is the currency of ChristJesus.app. Every need posted goes through a review process before it is visible to sponsors. This protects both the person in need and those who give.</p>
+
+      <!-- STEPS -->
+      <div class="relative my-6 pl-[19px]">
+        <div class="absolute bottom-0 left-[19px] top-0 w-px bg-[color:var(--rule)]"></div>
+
+        <div class="relative mb-7 flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">1</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Need Submission</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">The individual or a case manager on their behalf submits the need with documentation — bills, letters, or other supporting materials.</p>
+          </div>
+        </div>
+        <div class="relative mb-7 flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">2</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Case Manager Review</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">An assigned case manager (church leader, nonprofit partner, or platform-approved advocate) reviews and affirms the need within 48–72 hours.</p>
+          </div>
+        </div>
+        <div class="relative mb-7 flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">3</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Platform Approval</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">The ChristJesus.app team conducts a final review to confirm the need falls within guidelines before it is published and made visible to sponsors.</p>
+          </div>
+        </div>
+        <div class="relative mb-7 flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">4</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Funding &amp; Fulfillment</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Funds raised are disbursed directly to the verified vendor (landlord, utility company, etc.) wherever possible — not as cash to the recipient. This protects all parties.</p>
+          </div>
+        </div>
+        <div class="relative flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">5</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Outcome Reporting</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Sponsors receive a fulfillment confirmation. Recipients are invited to share a brief update, creating a relational loop that honors the gift.</p>
+          </div>
+        </div>
+      </div>
+
+      <p class="mt-6 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">We believe stewardship requires transparency. Anyone who misrepresents a need or provides false documentation will be permanently removed from the platform and may be subject to legal reporting.</p>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 05 SPONSORS -->
+  <section id="sponsors" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">05</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Giving</span>
+        Sponsors &amp; Donors
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Giving on ChristJesus.app is an act of worship, not charity as the world defines it. When you sponsor a need, you are participating in the ministry of the Church made visible.</p>
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><strong class="font-semibold text-[color:var(--ink)]">Sponsors may:</strong> Give one-time or recurring, remain anonymous, leave an encouraging message, follow the fulfillment of their gift, and give toward one need or a category of needs.</p>
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><strong class="font-semibold text-[color:var(--ink)]">Sponsors may not:</strong> Contact recipients directly outside the platform, attach conditions or requirements to their giving, use giving as a means of personal promotion or business marketing, or request the return of funds once a need is fulfilled.</p>
+
+      <div class="mt-7 rounded-r border-l-[3px] border-[color:var(--cj-secondary)] bg-[color:var(--gold-pale)] px-6 py-5">
+        <p class="font-display text-lg italic leading-relaxed text-[color:var(--ink)]">"Each of you should give what you have decided in your heart to give, not reluctantly or under compulsion, for God loves a cheerful giver." — 2 Corinthians 9:7</p>
+      </div>
+
+      <p class="mt-6 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Platform transparency note: ChristJesus.app may retain a small platform fee to sustain operations. This fee is always disclosed at checkout before any gift is processed. We are committed to keeping this as low as possible so that the maximum amount reaches those in need.</p>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 06 FUNDS -->
+  <section id="funds" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">06</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Stewardship</span>
+        How Funds Are Handled
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Money given on ChristJesus.app is held in trust until the verified need is fulfilled. We practice <strong class="font-semibold text-[color:var(--ink)]">direct-to-vendor disbursement</strong> as the standard — meaning we pay the landlord, the utility company, or the medical provider directly whenever possible.</p>
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">In cases where direct disbursement is not possible, funds are released to the case manager, who is accountable for their use and must confirm proper application. Funds are never released to recipients as unchecked cash transfers.</p>
+      <p class="text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">If a need is fully funded before you give, your contribution will either be applied to a related need you specify or returned within 5–7 business days. No gifts are held beyond 30 days without fulfillment.</p>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 07 CONDUCT -->
+  <section id="conduct" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">07</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Standards</span>
+        Community Conduct
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">ChristJesus.app is a sacred space. All users — those in need, those giving, and those managing — are expected to treat one another with the dignity that flows from knowing we are all made in the image of God.</p>
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">This means: no shaming, no condescension, no theological gatekeeping as a barrier to receiving help, no exploitation of someone's vulnerability, and no use of the platform for self-promotion or ministry branding at the expense of the people it serves.</p>
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">We welcome all believers and those exploring faith who are connected to a participating church or organization. Theological disagreements should never become a reason to withhold compassion.</p>
+
+      <div class="mt-7 rounded-r border-l-[3px] border-[color:var(--cj-secondary)] bg-[color:var(--gold-pale)] px-6 py-5">
+        <p class="font-display text-lg italic leading-relaxed text-[color:var(--ink)]">"Be kind and compassionate to one another, forgiving each other, just as in Christ God forgave you." — Ephesians 4:32</p>
+      </div>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 08 PROHIBITED -->
+  <section id="prohibited" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">08</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Boundaries</span>
+        Prohibited Uses
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">The following uses are strictly prohibited and will result in immediate account suspension:</p>
+
+      <div class="relative mt-5 rounded border border-[rgba(201,168,76,0.2)] bg-white p-6">
+        <div class="absolute left-0 top-0 h-[3px] w-full rounded-t bg-gradient-to-r from-[#A85252] to-[#C97070]"></div>
+        <p class="mb-3.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#A85252]">Zero Tolerance Violations</p>
+        <ul class="space-y-1.5">
+          <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Submitting fraudulent, exaggerated, or fabricated needs</li>
+          <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Using the platform to solicit funds for illegal activity</li>
+          <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Creating multiple accounts to circumvent review or limits</li>
+          <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Misrepresenting your role (case manager, recipient, sponsor)</li>
+          <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Harassment, threats, or abusive communication of any kind</li>
+          <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Using recipient information for any commercial purpose</li>
+          <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Posting needs on behalf of others without explicit consent</li>
+          <li class="flex gap-2.5 text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><span class="mt-0.5 shrink-0 text-xs text-[#A85252]">✕</span> Attempting to bypass the verification process in any way</li>
+        </ul>
+      </div>
+
+      <p class="mt-6 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">We are a small community governed by trust. The moment that trust is broken, the platform ceases to serve its purpose. We take these violations seriously and will not hesitate to act.</p>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 09 CONSEQUENCES -->
+  <section id="consequences" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">09</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Enforcement</span>
+        Violations &amp; Consequences
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-6 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">We believe in restoration wherever possible and accountability always. Violations are reviewed on a case-by-case basis with the following general framework:</p>
+
+      <div class="relative my-6 pl-[19px]">
+        <div class="absolute bottom-0 left-[19px] top-0 w-px bg-[color:var(--rule)]"></div>
+
+        <div class="relative mb-7 flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">1</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Warning &amp; Education</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Minor or first-time violations may receive a written warning with clarification of the relevant guideline.</p>
+          </div>
+        </div>
+        <div class="relative mb-7 flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">2</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Temporary Suspension</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Repeated or more significant violations may result in a 30–90 day suspension pending a review with a platform representative.</p>
+          </div>
+        </div>
+        <div class="relative mb-7 flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">3</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Permanent Removal</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Fraud, abuse, or zero-tolerance violations result in permanent account removal and notification of the relevant case manager or church partner.</p>
+          </div>
+        </div>
+        <div class="relative flex gap-5">
+          <div class="z-10 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[color:var(--cj-secondary)] font-display text-lg font-bold text-[#0D1B2A]">4</div>
+          <div class="pt-1.5">
+            <p class="mb-1 text-sm font-semibold text-[color:var(--ink)]">Legal Reporting</p>
+            <p class="text-[13.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">Fraudulent financial activity will be reported to the appropriate authorities. Protecting the integrity of the platform protects everyone in it.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="h-px w-full bg-[color:var(--rule)]"></div>
+
+  <!-- 10 CONTACT -->
+  <section id="contact" data-reveal class="my-16">
+    <div class="mb-7 flex items-start gap-5">
+      <span class="font-display text-5xl font-light text-[color:var(--cj-secondary)] opacity-30 leading-none shrink-0 -mt-1.5">10</span>
+      <h2 class="pt-2 font-display text-3xl font-semibold leading-tight text-[color:var(--ink)]">
+        <span class="mb-1.5 block font-sans text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--cj-secondary)]">Support</span>
+        Questions &amp; Disputes
+      </h2>
+    </div>
+    <div class="pl-0 sm:pl-[76px]">
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">We are a small, faith-driven team committed to handling every inquiry with care and promptness. If you have a question about these guidelines, believe a decision was made in error, or want to report a concern, we want to hear from you.</p>
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]"><strong class="font-semibold text-[color:var(--ink)]">Email:</strong> support@christjesus.app<br>
+      <strong class="font-semibold text-[color:var(--ink)]">Response time:</strong> Within 2 business days for general inquiries; within 24 hours for urgent safety or fraud concerns.</p>
+      <p class="mb-4 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">For disputes involving a denial of a need or a funding concern, you may request a secondary review by a different member of our team. We are committed to fairness, and no decision is beyond appeal.</p>
+
+      <div class="mt-7 rounded-r border-l-[3px] border-[color:var(--cj-secondary)] bg-[color:var(--gold-pale)] px-6 py-5">
+        <p class="font-display text-lg italic leading-relaxed text-[color:var(--ink)]">"If your brother or sister sins against you, go and point out their fault, just between the two of you." — Matthew 18:15</p>
+      </div>
+
+      <p class="mt-6 text-[15.5px] font-light leading-relaxed text-[color:var(--ink-soft)]">These guidelines are a living document. As ChristJesus.app grows, we will refine these policies in consultation with our community, our church partners, and the wisdom of Scripture. <strong class="font-semibold text-[color:var(--ink)]">Last updated: March 2026.</strong></p>
+    </div>
+  </section>
+
+</div>
+
+<style>
+  [data-reveal] {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+  }
+  [data-reveal].visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+</style>
+<script>
+  (() => {
+    const sections = document.querySelectorAll('[data-reveal]');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          e.target.classList.add('visible');
+          observer.unobserve(e.target);
+        }
+      });
+    }, { threshold: 0.08 });
+    sections.forEach((s) => observer.observe(s));
+  })();
+</script>
+
+{{template "footer" .}}
+{{end}}

--- a/internal/server/templates/pages/guidelines.html
+++ b/internal/server/templates/pages/guidelines.html
@@ -58,12 +58,12 @@
       <!-- PILLARS -->
       <div class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div class="rounded bg-[#0D1B2A] p-7 text-center">
-          <span class="mb-3.5 block text-2xl">✝</span>
+          <span class="mb-3.5 block text-2xl text-[color:var(--cj-accent)]">✝</span>
           <p class="mb-2 font-display text-xl font-semibold text-[color:var(--cj-accent)]">Christ-Centered</p>
           <p class="text-xs font-light leading-relaxed text-white/50">Every feature, every policy, every decision flows from the example of Jesus and the witness of Scripture.</p>
         </div>
         <div class="rounded bg-[#0D1B2A] p-7 text-center">
-          <span class="mb-3.5 block text-2xl">⚖</span>
+          <span class="mb-3.5 block text-2xl text-[color:var(--cj-accent)]">⚖</span>
           <p class="mb-2 font-display text-xl font-semibold text-[color:var(--cj-accent)]">Accountable</p>
           <p class="text-xs font-light leading-relaxed text-white/50">Needs are verified. Funds are tracked. Sponsors are supported by case managers. Nothing is anonymous or unchecked.</p>
         </div>


### PR DESCRIPTION
## Summary
- **Design tokens refresh**: New site-wide palette — gold (`#C9A84C`), midnight (`#0D1B2A`), cream (`#FAF7F0`) background, warm ink text. Fonts swapped to Cormorant Garamond (headings) + Jost (body).
- **Navbar update**: Cream background, branded `Christ<gold>Jesus</gold>.app` logo, gold hover states on links and dropdown.
- **Footer redesign**: Dark midnight background, centered layout with tagline "Bearing one another's burdens", gold accent links.
- **Sticky footer**: Layout wrapper uses flexbox so footer always sits at viewport bottom on short pages.
- **Guidelines page** (`/guidelines`): All 10 sections from the PM's design mockup — hero, verse band, TOC, mission pillars, eligibility cards, need categories (eligible/not-eligible), verification steps, sponsors, funds, conduct, prohibited uses, consequences, and contact. Includes IntersectionObserver scroll-reveal animations.

## Test plan
- [ ] Visit `/guidelines` and verify all 10 sections render with scroll-reveal fade-in
- [ ] Verify cream background (`#FAF7F0`) appears site-wide (not white)
- [ ] Check navbar logo shows `Christ` in midnight + `Jesus` in gold
- [ ] Check footer is visible on all pages (especially categories, profile)
- [ ] Verify footer sticks to bottom on short-content pages (e.g. login)
- [ ] Test responsive layout on mobile (TOC single-column, pillar cards stack, rule cards stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)