### PR TITLE
refactor: rename user type "need" to "recipient"

### DIFF
--- a/internal/seed/users.go
+++ b/internal/seed/users.go
@@ -18,20 +18,20 @@ type fakeUserSeed struct {
 }
 
 var fakeUsers = []fakeUserSeed{
-	{ID: "11111111-1111-1111-1111-111111111111", Email: "ava.williams+seed1@example.com", GivenName: "Ava", FamilyName: "Williams", UserType: types.UserTypeNeed},
-	{ID: "22222222-2222-2222-2222-222222222222", Email: "liam.johnson+seed2@example.com", GivenName: "Liam", FamilyName: "Johnson", UserType: types.UserTypeNeed},
-	{ID: "33333333-3333-3333-3333-333333333333", Email: "noah.brown+seed3@example.com", GivenName: "Noah", FamilyName: "Brown", UserType: types.UserTypeNeed},
-	{ID: "44444444-4444-4444-4444-444444444444", Email: "mia.davis+seed4@example.com", GivenName: "Mia", FamilyName: "Davis", UserType: types.UserTypeNeed},
-	{ID: "55555555-5555-5555-5555-555555555555", Email: "elijah.garcia+seed5@example.com", GivenName: "Elijah", FamilyName: "Garcia", UserType: types.UserTypeNeed},
-	{ID: "66666666-6666-6666-6666-666666666666", Email: "olivia.miller+seed6@example.com", GivenName: "Olivia", FamilyName: "Miller", UserType: types.UserTypeNeed},
-	{ID: "77777777-7777-7777-7777-777777777777", Email: "ethan.moore+seed7@example.com", GivenName: "Ethan", FamilyName: "Moore", UserType: types.UserTypeNeed},
-	{ID: "88888888-8888-8888-8888-888888888888", Email: "sophia.taylor+seed8@example.com", GivenName: "Sophia", FamilyName: "Taylor", UserType: types.UserTypeNeed},
+	{ID: "11111111-1111-1111-1111-111111111111", Email: "ava.williams+seed1@example.com", GivenName: "Ava", FamilyName: "Williams", UserType: types.UserTypeRecipient},
+	{ID: "22222222-2222-2222-2222-222222222222", Email: "liam.johnson+seed2@example.com", GivenName: "Liam", FamilyName: "Johnson", UserType: types.UserTypeRecipient},
+	{ID: "33333333-3333-3333-3333-333333333333", Email: "noah.brown+seed3@example.com", GivenName: "Noah", FamilyName: "Brown", UserType: types.UserTypeRecipient},
+	{ID: "44444444-4444-4444-4444-444444444444", Email: "mia.davis+seed4@example.com", GivenName: "Mia", FamilyName: "Davis", UserType: types.UserTypeRecipient},
+	{ID: "55555555-5555-5555-5555-555555555555", Email: "elijah.garcia+seed5@example.com", GivenName: "Elijah", FamilyName: "Garcia", UserType: types.UserTypeRecipient},
+	{ID: "66666666-6666-6666-6666-666666666666", Email: "olivia.miller+seed6@example.com", GivenName: "Olivia", FamilyName: "Miller", UserType: types.UserTypeRecipient},
+	{ID: "77777777-7777-7777-7777-777777777777", Email: "ethan.moore+seed7@example.com", GivenName: "Ethan", FamilyName: "Moore", UserType: types.UserTypeRecipient},
+	{ID: "88888888-8888-8888-8888-888888888888", Email: "sophia.taylor+seed8@example.com", GivenName: "Sophia", FamilyName: "Taylor", UserType: types.UserTypeRecipient},
 }
 
 func seedFakeNeedUserIDs() []string {
 	ids := make([]string, 0, len(fakeUsers))
 	for _, user := range fakeUsers {
-		if user.UserType == types.UserTypeNeed {
+		if user.UserType == types.UserTypeRecipient {
 			ids = append(ids, user.ID)
 		}
 	}

--- a/internal/server/onboarding.go
+++ b/internal/server/onboarding.go
@@ -27,7 +27,7 @@ func (s *Service) handleGetOnboarding(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	switch session.UserType {
-	case string(types.UserTypeNeed):
+	case string(types.UserTypeRecipient):
 		s.redirectNeedOnboarding(ctx, w, r, session.UserID)
 	case string(types.UserTypeDonor):
 		http.Redirect(w, r, s.route(RouteOnboardingDonorPreferences, nil), http.StatusSeeOther)
@@ -55,7 +55,7 @@ func (s *Service) handleGetOnboardingHowWeServeYou(w http.ResponseWriter, r *htt
 	// 	}
 	// } else if user.UserType != nil {
 	// 	switch *user.UserType {
-	// 	case string(types.UserTypeNeed):
+	// 	case string(types.UserTypeRecipient):
 	// 		s.redirectNeedOnboarding(ctx, w, r, userID)
 	// 		return
 	// 	case string(types.UserTypeDonor):
@@ -97,8 +97,8 @@ func (s *Service) handlePostOnboardingHowWeServeYou(w http.ResponseWriter, r *ht
 	}
 
 	switch onboarding.Path {
-	case "need":
-		userType := string(types.UserTypeNeed)
+	case "recipient":
+		userType := string(types.UserTypeRecipient)
 		err = s.setUserType(ctx, userType)
 		if err != nil {
 			s.logger.WithError(err).Error("failed to set user type")

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -43,7 +43,7 @@ func (s *Service) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 	myNeeds := make([]*types.Need, 0)
 	needSummaries := make([]types.ProfileNeedSummary, 0)
 	donationSummaries := make([]types.ProfileDonationSummary, 0)
-	if userType == string(types.UserTypeNeed) {
+	if userType == string(types.UserTypeRecipient) {
 		needs, err := s.needsRepo.NeedsByUser(ctx, session.UserID)
 		if err != nil {
 			if !errors.Is(err, types.ErrNeedNotFound) {
@@ -479,8 +479,8 @@ func buildProfileSidebar(userType string) []types.ProfileNavItem {
 	items := []types.ProfileNavItem{
 		{Label: "Profile Overview", Href: "#overview", Active: true, Section: "overview", ShowItem: true},
 		{Label: "Edit Profile", Href: "#edit-profile", Active: false, Section: "edit-profile", ShowItem: true},
-		{Label: "My Needs", Href: "#my-needs", Active: false, Section: "my-needs", ShowItem: userType == string(types.UserTypeNeed)},
-		{Label: "Need Status", Href: "#need-status", Active: false, Section: "need-status", ShowItem: userType == string(types.UserTypeNeed)},
+		{Label: "My Needs", Href: "#my-needs", Active: false, Section: "my-needs", ShowItem: userType == string(types.UserTypeRecipient)},
+		{Label: "Need Status", Href: "#need-status", Active: false, Section: "need-status", ShowItem: userType == string(types.UserTypeRecipient)},
 		{Label: "Donation History", Href: "#donations", Active: false, Section: "donations", ShowItem: userType == string(types.UserTypeDonor)},
 	}
 

--- a/internal/server/templates/pages/onboarding_how_we_serve_you.html
+++ b/internal/server/templates/pages/onboarding_how_we_serve_you.html
@@ -60,7 +60,7 @@
       <div class="p-6 pt-0">
         <form method="POST" action="{{route "onboarding.how.we.serve.you" nil}}">
           {{.CSRFField}}
-          <button type="submit" name="path" value="need"
+          <button type="submit" name="path" value="recipient"
             class="w-full px-4 py-3 bg-[color:var(--cj-primary)] text-white rounded-md font-medium hover:bg-[color:var(--cj-primary)]/90 transition-colors">
             Share Your Need
           </button>

--- a/internal/server/templates/pages/profile.html
+++ b/internal/server/templates/pages/profile.html
@@ -63,7 +63,7 @@
         </form>
       </div>
 
-      {{if eq .UserType "need"}}
+      {{if eq .UserType "recipient"}}
       <div id="my-needs" class="rounded-xl border bg-background p-6">
         <h2 class="text-xl font-semibold text-foreground">My Needs</h2>
         {{if .HasNeeds}}

--- a/migrations/users.pg.hcl
+++ b/migrations/users.pg.hcl
@@ -16,7 +16,7 @@ table "users" {
   column "user_type" {
     type    = text
     null    = true
-    comment = "need, donor, sponsor"
+    comment = "recipient, donor, sponsor"
   }
 
   column "email" {

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -5,7 +5,7 @@ import "time"
 type UserType string
 
 const (
-	UserTypeNeed    UserType = "need"
+	UserTypeRecipient UserType = "recipient"
 	UserTypeDonor   UserType = "donor"
 	UserTypeSponsor UserType = "sponsor"
 )


### PR DESCRIPTION
## Summary
- Renames `UserTypeNeed` to `UserTypeRecipient` and changes the stored value from `"need"` to `"recipient"`
- Clearer terminology — distinguishes the person from the need they submit
- Updates all Go references, template checks, form values, seed data, and schema comment

## Notes
- Requires a DB wipe or manual `UPDATE users SET user_type = 'recipient' WHERE user_type = 'need'` — no migration included since the column is free-form text with no constraint

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Wipe DB and re-seed, verify new users get `recipient` user type
- [ ] Onboarding flow: selecting "Share Your Need" sets user type to `recipient`
- [ ] Profile page: recipient users see My Needs / Need Status sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)