### PR TITLE
feat(admin): add user management with type-specific detail views

### DIFF
--- a/internal/server/admin_users.go
+++ b/internal/server/admin_users.go
@@ -1,0 +1,311 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"christjesus/pkg/types"
+)
+
+const adminUsersPageSize = 20
+
+func (s *Service) handleGetAdminUsers(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	page := parsePositiveInt(r.URL.Query().Get("page"), 1)
+	search := strings.TrimSpace(r.URL.Query().Get("search"))
+	selectedType := strings.TrimSpace(r.URL.Query().Get("type"))
+
+	totalUsers, err := s.userRepo.CountUsers(ctx, search, selectedType)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to count users for admin list")
+		s.internalServerError(w)
+		return
+	}
+
+	totalPages := totalUsers / adminUsersPageSize
+	if totalUsers%adminUsersPageSize != 0 {
+		totalPages++
+	}
+	if totalPages == 0 {
+		totalPages = 1
+	}
+	if page > totalPages {
+		page = totalPages
+	}
+
+	users, err := s.userRepo.ListUsers(ctx, page, adminUsersPageSize, search, selectedType)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to list users for admin")
+		s.internalServerError(w)
+		return
+	}
+
+	items := make([]*types.AdminUserListItem, 0, len(users))
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+
+		email := ""
+		if user.Email != nil {
+			email = *user.Email
+		}
+		givenName := ""
+		if user.GivenName != nil {
+			givenName = *user.GivenName
+		}
+		familyName := ""
+		if user.FamilyName != nil {
+			familyName = *user.FamilyName
+		}
+		userType := "-"
+		if user.UserType != nil && *user.UserType != "" {
+			userType = *user.UserType
+		}
+
+		items = append(items, &types.AdminUserListItem{
+			UserID:     user.ID,
+			Email:      email,
+			GivenName:  givenName,
+			FamilyName: familyName,
+			UserType:   userType,
+			CreatedAt:  user.CreatedAt.Format(time.DateOnly),
+			DetailHref: s.route(RouteAdminUserDetail, map[string]string{"userID": user.ID}),
+		})
+	}
+
+	buildPageHref := func(p int) string {
+		v := url.Values{}
+		v.Set("page", strconv.Itoa(p))
+		if search != "" {
+			v.Set("search", search)
+		}
+		if selectedType != "" {
+			v.Set("type", selectedType)
+		}
+		return s.routeWithQuery(RouteAdminUsers, nil, v)
+	}
+
+	prevHref := ""
+	if page > 1 {
+		prevHref = buildPageHref(page - 1)
+	}
+	nextHref := ""
+	if page < totalPages {
+		nextHref = buildPageHref(page + 1)
+	}
+
+	data := &types.AdminUsersPageData{
+		BasePageData: types.BasePageData{Title: "Admin Users"},
+		Users:        items,
+		Page:         page,
+		PageSize:     adminUsersPageSize,
+		TotalUsers:   totalUsers,
+		TotalPages:   totalPages,
+		PrevHref:     prevHref,
+		NextHref:     nextHref,
+		Search:       search,
+		SelectedType: selectedType,
+		FilterAction: s.route(RouteAdminUsers, nil),
+		BackHref:     s.route(RouteAdmin, nil),
+	}
+
+	if err := s.renderTemplate(w, r, "page.admin.users", data); err != nil {
+		s.logger.WithError(err).Error("failed to render admin users page")
+		s.internalServerError(w)
+		return
+	}
+}
+
+func (s *Service) handleGetAdminUserDetail(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID := strings.TrimSpace(r.PathValue("userID"))
+	if userID == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	user, err := s.userRepo.User(ctx, userID)
+	if err != nil {
+		s.logger.WithError(err).WithField("user_id", userID).Error("failed to fetch user for admin detail")
+		http.NotFound(w, r)
+		return
+	}
+
+	email := ""
+	if user.Email != nil {
+		email = *user.Email
+	}
+	givenName := ""
+	if user.GivenName != nil {
+		givenName = *user.GivenName
+	}
+	familyName := ""
+	if user.FamilyName != nil {
+		familyName = *user.FamilyName
+	}
+	authSubject := ""
+	if user.AuthSubject != nil {
+		authSubject = *user.AuthSubject
+	}
+	userType := "-"
+	if user.UserType != nil && *user.UserType != "" {
+		userType = *user.UserType
+	}
+
+	data := &types.AdminUserDetailPageData{
+		BasePageData: types.BasePageData{Title: "User: " + givenName + " " + familyName},
+		UserID:       user.ID,
+		Email:        email,
+		GivenName:    givenName,
+		FamilyName:   familyName,
+		AuthSubject:  authSubject,
+		UserType:     userType,
+		CreatedAt:    user.CreatedAt.Format(time.DateTime),
+		UpdatedAt:    user.UpdatedAt.Format(time.DateTime),
+		BackHref:     s.route(RouteAdminUsers, nil),
+	}
+
+	if userType == string(types.UserTypeRecipient) {
+		s.populateAdminRecipientData(ctx, data, userID)
+	} else if userType == string(types.UserTypeDonor) {
+		s.populateAdminDonorData(ctx, data, userID)
+	}
+
+	if err := s.renderTemplate(w, r, "page.admin.user.detail", data); err != nil {
+		s.logger.WithError(err).Error("failed to render admin user detail page")
+		s.internalServerError(w)
+		return
+	}
+}
+
+func (s *Service) populateAdminRecipientData(ctx context.Context, data *types.AdminUserDetailPageData, userID string) {
+	data.IsRecipient = true
+
+	needs, err := s.needsRepo.NeedsByUser(ctx, userID)
+	if err != nil {
+		s.logger.WithError(err).WithField("user_id", userID).Error("failed to fetch needs for admin user detail")
+		return
+	}
+
+	var activeCount int
+	var totalRaisedCents int
+	items := make([]*types.AdminUserNeedItem, 0, len(needs))
+	for _, need := range needs {
+		if need == nil {
+			continue
+		}
+
+		if need.Status == types.NeedStatusActive {
+			activeCount++
+		}
+		totalRaisedCents += need.AmountRaisedCents
+
+		fundingPercent := 0
+		if need.AmountNeededCents > 0 {
+			fundingPercent = need.AmountRaisedCents * 100 / need.AmountNeededCents
+		}
+
+		desc := ""
+		if need.ShortDescription != nil {
+			desc = *need.ShortDescription
+		}
+
+		items = append(items, &types.AdminUserNeedItem{
+			NeedID:           need.ID,
+			ShortDescription: desc,
+			Status:           need.Status,
+			AmountNeeded:     formatUSDFromCents(need.AmountNeededCents),
+			AmountRaised:     formatUSDFromCents(need.AmountRaisedCents),
+			FundingPercent:   fundingPercent,
+			CreatedAt:        need.CreatedAt.Format(time.DateOnly),
+			ReviewHref:       s.route(RouteAdminNeedReview, map[string]string{"needID": need.ID}),
+		})
+	}
+
+	data.Needs = items
+	data.HasNeeds = len(items) > 0
+	data.TotalNeeds = len(items)
+	data.NeedsSummary = fmt.Sprintf("%d needs, %d active, %s raised", len(items), activeCount, formatUSDFromCents(totalRaisedCents))
+}
+
+func (s *Service) populateAdminDonorData(ctx context.Context, data *types.AdminUserDetailPageData, userID string) {
+	data.IsDonor = true
+
+	intents, err := s.donationIntentRepo.DonationIntentsByDonorUserID(ctx, userID)
+	if err != nil {
+		s.logger.WithError(err).WithField("user_id", userID).Error("failed to fetch donations for admin user detail")
+		return
+	}
+
+	// Collect distinct need IDs for labels
+	distinctNeedIDs := make([]string, 0, len(intents))
+	seenNeedIDs := make(map[string]bool)
+	for _, intent := range intents {
+		if intent == nil {
+			continue
+		}
+		needID := strings.TrimSpace(intent.NeedID)
+		if needID == "" || seenNeedIDs[needID] {
+			continue
+		}
+		seenNeedIDs[needID] = true
+		distinctNeedIDs = append(distinctNeedIDs, needID)
+	}
+
+	needLabelByID := make(map[string]string, len(distinctNeedIDs))
+	if len(distinctNeedIDs) > 0 {
+		needs, err := s.needsRepo.NeedsByIDs(ctx, distinctNeedIDs)
+		if err != nil {
+			s.logger.WithError(err).WithField("user_id", userID).Error("failed to batch fetch needs for admin donor detail")
+		} else {
+			for _, need := range needs {
+				if need == nil {
+					continue
+				}
+				label := "Need request"
+				if need.ShortDescription != nil && strings.TrimSpace(*need.ShortDescription) != "" {
+					label = *need.ShortDescription
+				}
+				needLabelByID[need.ID] = label
+			}
+		}
+	}
+
+	var totalCents int
+	items := make([]*types.AdminUserDonationItem, 0, len(intents))
+	for _, intent := range intents {
+		if intent == nil {
+			continue
+		}
+
+		needLabel := needLabelByID[intent.NeedID]
+		if strings.TrimSpace(needLabel) == "" {
+			needLabel = "Need request"
+		}
+
+		if strings.ToLower(intent.PaymentStatus) == types.DonationPaymentStatusFinalized {
+			totalCents += intent.AmountCents
+		}
+
+		items = append(items, &types.AdminUserDonationItem{
+			IntentID:    intent.ID,
+			NeedID:      intent.NeedID,
+			NeedLabel:   needLabel,
+			Amount:      formatUSDFromCents(intent.AmountCents),
+			Status:      formatDonationStatus(intent.PaymentStatus),
+			IsAnonymous: intent.IsAnonymous,
+			CreatedAt:   intent.CreatedAt.Format(time.DateOnly),
+		})
+	}
+
+	data.Donations = items
+	data.HasDonations = len(items) > 0
+	data.TotalDonations = len(items)
+	data.DonationsSummary = fmt.Sprintf("%d donations, %s finalized total", len(items), formatUSDFromCents(totalCents))
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -27,6 +27,8 @@ const (
 	RouteAdminNeedDelete           RouteName = "admin.need.delete"
 	RouteAdminNeedRestore          RouteName = "admin.need.restore"
 	RouteAdminNeedMessage          RouteName = "admin.need.message"
+	RouteAdminUsers                RouteName = "admin.users"
+	RouteAdminUserDetail           RouteName = "admin.user.detail"
 	RouteProfileNeedDelete         RouteName = "profile.need.delete"
 	RouteProfileNeedReview         RouteName = "profile.need.review"
 	RouteProfileNeedReviewPost     RouteName = "profile.need.review.post"
@@ -101,6 +103,8 @@ var routePatterns = map[RouteName]string{
 	RouteAdminNeedDelete:               "/admin/needs/:needID/delete",
 	RouteAdminNeedRestore:              "/admin/needs/:needID/restore",
 	RouteAdminNeedMessage:              "/admin/needs/:needID/messages",
+	RouteAdminUsers:                    "/admin/users",
+	RouteAdminUserDetail:               "/admin/users/:userID",
 	RouteProfileNeedDelete:             "/profile/needs/:needID/delete",
 	RouteProfileNeedReview:             "/profile/needs/:needID/review",
 	RouteProfileNeedReviewPost:         "/profile/needs/:needID/review/messages",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -262,6 +262,8 @@ func (s *Service) buildRouter(r *flow.Mux, csrfKey []byte) {
 			r.HandleFunc(RoutePattern(RouteAdminNeedDelete), s.handlePostAdminNeedDelete, http.MethodPost)
 			r.HandleFunc(RoutePattern(RouteAdminNeedRestore), s.handlePostAdminNeedRestore, http.MethodPost)
 			r.HandleFunc(RoutePattern(RouteAdminNeedMessage), s.handlePostAdminNeedMessage, http.MethodPost)
+			r.HandleFunc(RoutePattern(RouteAdminUsers), s.handleGetAdminUsers, http.MethodGet)
+			r.HandleFunc(RoutePattern(RouteAdminUserDetail), s.handleGetAdminUserDetail, http.MethodGet)
 		})
 	})
 

--- a/internal/server/templates/pages/admin-dashboard.html
+++ b/internal/server/templates/pages/admin-dashboard.html
@@ -12,6 +12,9 @@
       <a href="{{route "admin.need.explorer" nil}}"
         class="ml-3 inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted">Open
         Need Explorer</a>
+      <a href="{{route "admin.users" nil}}"
+        class="ml-3 inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted">Manage
+        Users</a>
     </div>
   </div>
 </section>

--- a/internal/server/templates/pages/admin-user-detail.html
+++ b/internal/server/templates/pages/admin-user-detail.html
@@ -1,0 +1,146 @@
+{{define "page.admin.user.detail"}}
+{{template "header" .}}
+<section class="mx-auto w-full max-w-4xl px-4 py-12 md:px-6">
+  <div class="rounded-2xl border border-border bg-card p-6 shadow-sm">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Admin / Users</p>
+        <h1 class="mt-2 text-2xl font-semibold text-foreground">{{.GivenName}} {{.FamilyName}}</h1>
+      </div>
+      <div>
+        <a href="{{.BackHref}}" class="text-sm text-muted-foreground hover:text-foreground">Back to Users</a>
+      </div>
+    </div>
+
+    <dl class="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wider text-muted-foreground">User ID</dt>
+        <dd class="mt-1 font-mono text-sm text-foreground">{{.UserID}}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Auth Subject</dt>
+        <dd class="mt-1 font-mono text-sm text-foreground">{{if .AuthSubject}}{{.AuthSubject}}{{else}}-{{end}}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Email</dt>
+        <dd class="mt-1 text-sm text-foreground">{{if .Email}}{{.Email}}{{else}}-{{end}}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wider text-muted-foreground">User Type</dt>
+        <dd class="mt-1 text-sm">
+          <span class="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-xs font-medium">{{.UserType}}</span>
+        </dd>
+      </div>
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Given Name</dt>
+        <dd class="mt-1 text-sm text-foreground">{{if .GivenName}}{{.GivenName}}{{else}}-{{end}}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Family Name</dt>
+        <dd class="mt-1 text-sm text-foreground">{{if .FamilyName}}{{.FamilyName}}{{else}}-{{end}}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Created At</dt>
+        <dd class="mt-1 text-sm text-foreground">{{.CreatedAt}}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Updated At</dt>
+        <dd class="mt-1 text-sm text-foreground">{{.UpdatedAt}}</dd>
+      </div>
+    </dl>
+  </div>
+
+  {{if .IsRecipient}}
+  <div class="mt-6 rounded-2xl border border-border bg-card p-6 shadow-sm">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <h2 class="text-lg font-semibold text-foreground">Submitted Needs</h2>
+        {{if .HasNeeds}}
+        <p class="mt-1 text-xs text-muted-foreground">{{.NeedsSummary}}</p>
+        {{end}}
+      </div>
+    </div>
+
+    {{if .HasNeeds}}
+    <div class="mt-4 overflow-x-auto">
+      <table class="min-w-full divide-y divide-border text-sm">
+        <thead>
+          <tr class="text-left text-muted-foreground">
+            <th class="py-2 pr-4">Description</th>
+            <th class="py-2 pr-4">Status</th>
+            <th class="py-2 pr-4">Needed</th>
+            <th class="py-2 pr-4">Raised</th>
+            <th class="py-2 pr-4">Funded</th>
+            <th class="py-2 pr-4">Created</th>
+            <th class="py-2">Review</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border">
+          {{range .Needs}}
+          <tr>
+            <td class="py-3 pr-4 max-w-[200px] truncate">{{if .ShortDescription}}{{.ShortDescription}}{{else}}-{{end}}</td>
+            <td class="py-3 pr-4">
+              <span class="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-xs font-medium">{{.Status}}</span>
+            </td>
+            <td class="py-3 pr-4">{{.AmountNeeded}}</td>
+            <td class="py-3 pr-4">{{.AmountRaised}}</td>
+            <td class="py-3 pr-4">{{.FundingPercent}}%</td>
+            <td class="py-3 pr-4">{{.CreatedAt}}</td>
+            <td class="py-3"><a href="{{.ReviewHref}}" class="text-[color:var(--cj-primary)] hover:underline">Open</a></td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{else}}
+    <p class="mt-4 text-sm text-muted-foreground">No needs submitted yet.</p>
+    {{end}}
+  </div>
+  {{end}}
+
+  {{if .IsDonor}}
+  <div class="mt-6 rounded-2xl border border-border bg-card p-6 shadow-sm">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <h2 class="text-lg font-semibold text-foreground">Donation History</h2>
+        {{if .HasDonations}}
+        <p class="mt-1 text-xs text-muted-foreground">{{.DonationsSummary}}</p>
+        {{end}}
+      </div>
+    </div>
+
+    {{if .HasDonations}}
+    <div class="mt-4 overflow-x-auto">
+      <table class="min-w-full divide-y divide-border text-sm">
+        <thead>
+          <tr class="text-left text-muted-foreground">
+            <th class="py-2 pr-4">Need</th>
+            <th class="py-2 pr-4">Amount</th>
+            <th class="py-2 pr-4">Status</th>
+            <th class="py-2 pr-4">Anonymous</th>
+            <th class="py-2">Date</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border">
+          {{range .Donations}}
+          <tr>
+            <td class="py-3 pr-4 max-w-[200px] truncate">{{.NeedLabel}}</td>
+            <td class="py-3 pr-4">{{.Amount}}</td>
+            <td class="py-3 pr-4">
+              <span class="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-xs font-medium">{{.Status}}</span>
+            </td>
+            <td class="py-3 pr-4">{{if .IsAnonymous}}Yes{{else}}No{{end}}</td>
+            <td class="py-3">{{.CreatedAt}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{else}}
+    <p class="mt-4 text-sm text-muted-foreground">No donations yet.</p>
+    {{end}}
+  </div>
+  {{end}}
+</section>
+{{template "footer" .}}
+{{end}}

--- a/internal/server/templates/pages/admin-users.html
+++ b/internal/server/templates/pages/admin-users.html
@@ -1,0 +1,90 @@
+{{define "page.admin.users"}}
+{{template "header" .}}
+<section class="mx-auto w-full max-w-6xl px-4 py-12 md:px-6">
+  <div class="rounded-2xl border border-border bg-card p-6 shadow-sm">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Admin</p>
+        <h1 class="mt-2 text-2xl font-semibold text-foreground">Users</h1>
+      </div>
+      <div class="flex items-center gap-3">
+        <a href="{{.BackHref}}" class="text-sm text-muted-foreground hover:text-foreground">Back to Dashboard</a>
+      </div>
+    </div>
+
+    <form method="GET" action="{{.FilterAction}}" class="mt-6 flex flex-wrap items-end gap-3">
+      <div class="flex-1 min-w-[200px]">
+        <label for="search" class="block text-xs font-medium text-muted-foreground mb-1">Search</label>
+        <input type="text" id="search" name="search" value="{{.Search}}" placeholder="Name or email..."
+          class="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[color:var(--cj-secondary)]" />
+      </div>
+      <div class="min-w-[140px]">
+        <label for="type" class="block text-xs font-medium text-muted-foreground mb-1">User Type</label>
+        <select id="type" name="type"
+          class="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-[color:var(--cj-secondary)]">
+          <option value="">All</option>
+          <option value="recipient" {{if eq .SelectedType "recipient"}}selected{{end}}>Recipient</option>
+          <option value="donor" {{if eq .SelectedType "donor"}}selected{{end}}>Donor</option>
+          <option value="sponsor" {{if eq .SelectedType "sponsor"}}selected{{end}}>Sponsor</option>
+        </select>
+      </div>
+      <button type="submit"
+        class="h-9 inline-flex items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
+        Filter
+      </button>
+      {{if or .Search .SelectedType}}
+      <a href="{{.FilterAction}}"
+        class="h-9 inline-flex items-center justify-center rounded-md border border-border px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted">
+        Clear
+      </a>
+      {{end}}
+    </form>
+
+    {{if .Users}}
+    <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+      <p>Showing page {{.Page}} of {{.TotalPages}} ({{.TotalUsers}} users)</p>
+      <div class="flex items-center gap-2">
+        {{if .PrevHref}}
+        <a href="{{.PrevHref}}" class="inline-flex h-8 items-center justify-center rounded-md border border-border px-3 text-xs font-medium text-foreground hover:bg-muted">Previous</a>
+        {{end}}
+        {{if .NextHref}}
+        <a href="{{.NextHref}}" class="inline-flex h-8 items-center justify-center rounded-md border border-border px-3 text-xs font-medium text-foreground hover:bg-muted">Next</a>
+        {{end}}
+      </div>
+    </div>
+
+    <div class="mt-6 overflow-x-auto">
+      <table class="min-w-full divide-y divide-border text-sm">
+        <thead>
+          <tr class="text-left text-muted-foreground">
+            <th class="py-2 pr-4">Name</th>
+            <th class="py-2 pr-4">Email</th>
+            <th class="py-2 pr-4">Type</th>
+            <th class="py-2 pr-4">Created</th>
+            <th class="py-2">View</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border">
+          {{range .Users}}
+          <tr>
+            <td class="py-3 pr-4">
+              <a href="{{.DetailHref}}" class="hover:underline">{{.GivenName}} {{.FamilyName}}</a>
+            </td>
+            <td class="py-3 pr-4 text-muted-foreground">{{.Email}}</td>
+            <td class="py-3 pr-4">
+              <span class="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-xs font-medium">{{.UserType}}</span>
+            </td>
+            <td class="py-3 pr-4">{{.CreatedAt}}</td>
+            <td class="py-3"><a href="{{.DetailHref}}" class="text-[color:var(--cj-primary)] hover:underline">Open</a></td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{else}}
+    <p class="mt-6 text-sm text-muted-foreground">No users found.</p>
+    {{end}}
+  </div>
+</section>
+{{template "footer" .}}
+{{end}}

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -116,6 +116,78 @@ func (r *UserRepository) Update(ctx context.Context, userID string, user *types.
 	return nil
 }
 
+func (r *UserRepository) ListUsers(ctx context.Context, page, pageSize int, search, userType string) ([]*types.User, error) {
+	builder := psql().
+		Select(userColumns...).
+		From(userTableName).
+		OrderBy("created_at DESC")
+
+	search = strings.TrimSpace(search)
+	if search != "" {
+		like := "%" + search + "%"
+		builder = builder.Where(sq.Or{
+			sq.ILike{"email": like},
+			sq.ILike{"given_name": like},
+			sq.ILike{"family_name": like},
+		})
+	}
+
+	userType = strings.TrimSpace(userType)
+	if userType != "" {
+		builder = builder.Where(sq.Eq{"user_type": userType})
+	}
+
+	offset := (page - 1) * pageSize
+	builder = builder.Limit(uint64(pageSize)).Offset(uint64(offset))
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate list users query: %w", err)
+	}
+
+	var users []*types.User
+	err = pgxscan.Select(ctx, r.pool, &users, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users: %w", err)
+	}
+
+	return users, nil
+}
+
+func (r *UserRepository) CountUsers(ctx context.Context, search, userType string) (int, error) {
+	builder := psql().
+		Select("COUNT(*)").
+		From(userTableName)
+
+	search = strings.TrimSpace(search)
+	if search != "" {
+		like := "%" + search + "%"
+		builder = builder.Where(sq.Or{
+			sq.ILike{"email": like},
+			sq.ILike{"given_name": like},
+			sq.ILike{"family_name": like},
+		})
+	}
+
+	userType = strings.TrimSpace(userType)
+	if userType != "" {
+		builder = builder.Where(sq.Eq{"user_type": userType})
+	}
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("failed to generate count users query: %w", err)
+	}
+
+	var count int
+	err = r.pool.QueryRow(ctx, query, args...).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count users: %w", err)
+	}
+
+	return count, nil
+}
+
 func (r *UserRepository) UpsertIdentity(ctx context.Context, authSubject, email, givenName, familyName string) (string, error) {
 	authSubject = strings.TrimSpace(authSubject)
 	if authSubject == "" {

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -526,3 +526,76 @@ type AdminNeedTimelineItem struct {
 	Note       string
 	DocumentID string
 }
+
+type AdminUsersPageData struct {
+	BasePageData
+	Users        []*AdminUserListItem
+	Page         int
+	PageSize     int
+	TotalUsers   int
+	TotalPages   int
+	PrevHref     string
+	NextHref     string
+	Search       string
+	SelectedType string
+	FilterAction string
+	BackHref     string
+}
+
+type AdminUserListItem struct {
+	UserID     string
+	Email      string
+	GivenName  string
+	FamilyName string
+	UserType   string
+	CreatedAt  string
+	DetailHref string
+}
+
+type AdminUserDetailPageData struct {
+	BasePageData
+	UserID      string
+	Email       string
+	GivenName   string
+	FamilyName  string
+	AuthSubject string
+	UserType    string
+	CreatedAt   string
+	UpdatedAt   string
+	BackHref    string
+
+	// Recipient-specific
+	IsRecipient   bool
+	Needs         []*AdminUserNeedItem
+	HasNeeds      bool
+	TotalNeeds    int
+	NeedsSummary  string // e.g. "3 needs, 1 active, $450.00 raised"
+
+	// Donor-specific
+	IsDonor          bool
+	Donations        []*AdminUserDonationItem
+	HasDonations     bool
+	TotalDonations   int
+	DonationsSummary string // e.g. "5 donations, $1,200.00 total"
+}
+
+type AdminUserNeedItem struct {
+	NeedID          string
+	ShortDescription string
+	Status          NeedStatus
+	AmountNeeded    string
+	AmountRaised    string
+	FundingPercent  int
+	CreatedAt       string
+	ReviewHref      string
+}
+
+type AdminUserDonationItem struct {
+	IntentID    string
+	NeedID      string
+	NeedLabel   string
+	Amount      string
+	Status      string
+	IsAnonymous bool
+	CreatedAt   string
+}


### PR DESCRIPTION
## Summary
- Add admin user list page at `/admin/users` with search by name/email, filter by user type, and pagination
- Add admin user detail page at `/admin/users/:userID` with type-specific sections:
  - **Recipients**: shows submitted needs table with status, funding progress, and review links
  - **Donors**: shows donation history table with amounts, payment status, and anonymity flag
- Add `ListUsers`/`CountUsers` store queries with search and type filtering
- Add "Manage Users" link to admin dashboard

Closes #25

## Test plan
- [ ] Navigate to admin dashboard, verify "Manage Users" button appears
- [ ] Visit `/admin/users`, verify user list renders with pagination
- [ ] Test search by name and email
- [ ] Test type filter dropdown (recipient, donor, all)
- [ ] Click a recipient user, verify needs table appears
- [ ] Click a donor user, verify donation history table appears
- [ ] Click a user with no type, verify only basic info shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)