### PR TITLE
Enhance donor onboarding, dashboard, discovery and donation flow

### DIFF
--- a/internal/server/donate.go
+++ b/internal/server/donate.go
@@ -256,6 +256,29 @@ func (s *Service) handleGetNeedDonateConfirmation(w http.ResponseWriter, r *http
 		return
 	}
 
+	primaryCategoryID := ""
+	var relatedNeeds []*types.BrowseNeedCard
+	assignments, aErr := s.needCategoryAssignmentsRepo.GetAssignmentsByNeedID(ctx, needID)
+	if aErr != nil {
+		s.logger.WithError(aErr).WithField("need_id", needID).Warn("failed to load category assignments for confirmation related needs")
+	} else {
+		for _, a := range assignments {
+			if a.IsPrimary {
+				primaryCategoryID = a.CategoryID
+				break
+			}
+		}
+	}
+
+	if primaryCategoryID != "" {
+		relNeeds, rErr := s.needsRepo.NeedsByCategoryExcluding(ctx, primaryCategoryID, needID, 3)
+		if rErr != nil {
+			s.logger.WithError(rErr).WithField("need_id", needID).Warn("failed to load related needs for confirmation")
+		} else if len(relNeeds) > 0 {
+			relatedNeeds = s.buildNeedCards(ctx, relNeeds, "confirmation related needs")
+		}
+	}
+
 	data := &types.NeedDonateConfirmationPageData{
 		BasePageData:       types.BasePageData{Title: "Donation Confirmation"},
 		NeedID:             need.ID,
@@ -264,6 +287,7 @@ func (s *Service) handleGetNeedDonateConfirmation(w http.ResponseWriter, r *http
 		AmountCents:        intent.AmountCents,
 		IsAnonymous:        intent.IsAnonymous,
 		PrimaryCategory:    primaryCategory,
+		PrimaryCategoryID:  primaryCategoryID,
 		PaymentStatus:      intent.PaymentStatus,
 		StatusLabel:        donationStatusLabel(intent.PaymentStatus),
 		StatusTitle:        donationStatusTitle(intent.PaymentStatus, ownerName),
@@ -272,6 +296,7 @@ func (s *Service) handleGetNeedDonateConfirmation(w http.ResponseWriter, r *http
 		ShowRetryCTA:       intent.PaymentStatus == types.DonationPaymentStatusFailed || intent.PaymentStatus == types.DonationPaymentStatusCanceled,
 		ShowReceiptDetails: intent.PaymentStatus == types.DonationPaymentStatusFinalized,
 		DonationDate:       donationConfirmationDate(intent),
+		RelatedNeeds:       relatedNeeds,
 	}
 
 	if err := s.renderTemplate(w, r, "page.need-donate-confirmation", data); err != nil {
@@ -362,11 +387,45 @@ func (s *Service) buildNeedDonatePageData(ctx context.Context, needID string, da
 	data.ShortDescription = need.ShortDescription
 	data.AmountNeededCents = need.AmountNeededCents
 	data.AmountRaisedCents = need.AmountRaisedCents
-	if len(data.PresetAmounts) == 0 {
-		data.PresetAmounts = donatePresetAmounts
+
+	remainingCents := need.AmountNeededCents - need.AmountRaisedCents
+	if remainingCents < 0 {
+		remainingCents = 0
 	}
+	data.RemainingCents = remainingCents
+
+	data.PresetAmounts = buildSmartPresets(remainingCents, donatePresetAmounts)
 
 	return data, nil
+}
+
+func buildSmartPresets(remainingCents int, standardPresets []int) []int {
+	if remainingCents <= 0 {
+		return standardPresets
+	}
+
+	remainingDollars := remainingCents / 100
+	if remainingCents%100 != 0 {
+		remainingDollars++
+	}
+
+	isStandard := false
+	for _, preset := range standardPresets {
+		if preset == remainingDollars {
+			isStandard = true
+			break
+		}
+	}
+
+	presets := make([]int, 0, len(standardPresets)+1)
+	if !isStandard {
+		presets = append(presets, remainingDollars)
+	}
+	for _, preset := range standardPresets {
+		presets = append(presets, preset)
+	}
+
+	return presets
 }
 
 func (s *Service) loadNeedDonateSummary(ctx context.Context, needID string) (*types.Need, string, string, error) {

--- a/internal/server/donate_test.go
+++ b/internal/server/donate_test.go
@@ -1,0 +1,274 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestBuildSmartPresets(t *testing.T) {
+	t.Parallel()
+
+	standardPresets := []int{25, 50, 100, 250}
+
+	tests := []struct {
+		name           string
+		remainingCents int
+		standardPresets []int
+		expected       []int
+	}{
+		{
+			name:            "remaining $73 prepends 73 to presets",
+			remainingCents:  7300,
+			standardPresets: standardPresets,
+			expected:        []int{73, 25, 50, 100, 250},
+		},
+		{
+			name:            "remaining $0 returns standard presets",
+			remainingCents:  0,
+			standardPresets: standardPresets,
+			expected:        standardPresets,
+		},
+		{
+			name:            "negative remaining returns standard presets",
+			remainingCents:  -500,
+			standardPresets: standardPresets,
+			expected:        standardPresets,
+		},
+		{
+			name:            "remaining exactly matches existing preset $50",
+			remainingCents:  5000,
+			standardPresets: standardPresets,
+			expected:        []int{25, 50, 100, 250},
+		},
+		{
+			name:            "remaining exactly matches existing preset $25",
+			remainingCents:  2500,
+			standardPresets: standardPresets,
+			expected:        []int{25, 50, 100, 250},
+		},
+		{
+			name:            "remaining exactly matches existing preset $100",
+			remainingCents:  10000,
+			standardPresets: standardPresets,
+			expected:        []int{25, 50, 100, 250},
+		},
+		{
+			name:            "remaining exactly matches existing preset $250",
+			remainingCents:  25000,
+			standardPresets: standardPresets,
+			expected:        []int{25, 50, 100, 250},
+		},
+		{
+			name:            "fractional cents rounds up to next dollar",
+			remainingCents:  7350,
+			standardPresets: standardPresets,
+			expected:        []int{74, 25, 50, 100, 250},
+		},
+		{
+			name:            "1 cent remaining rounds up to $1",
+			remainingCents:  1,
+			standardPresets: standardPresets,
+			expected:        []int{1, 25, 50, 100, 250},
+		},
+		{
+			name:            "99 cents remaining rounds up to $1",
+			remainingCents:  99,
+			standardPresets: standardPresets,
+			expected:        []int{1, 25, 50, 100, 250},
+		},
+		{
+			name:            "large remaining amount $500",
+			remainingCents:  50000,
+			standardPresets: standardPresets,
+			expected:        []int{500, 25, 50, 100, 250},
+		},
+		{
+			name:            "empty standard presets with remaining",
+			remainingCents:  7300,
+			standardPresets: []int{},
+			expected:        []int{73},
+		},
+		{
+			name:            "empty standard presets with zero remaining",
+			remainingCents:  0,
+			standardPresets: []int{},
+			expected:        []int{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := buildSmartPresets(tt.remainingCents, tt.standardPresets)
+
+			if len(actual) != len(tt.expected) {
+				t.Fatalf("buildSmartPresets() returned %d items %v, want %d items %v",
+					len(actual), actual, len(tt.expected), tt.expected)
+			}
+
+			for i := range tt.expected {
+				if actual[i] != tt.expected[i] {
+					t.Fatalf("buildSmartPresets()[%d] = %d, want %d (full result: %v)",
+						i, actual[i], tt.expected[i], actual)
+				}
+			}
+		})
+	}
+}
+
+func TestParseDonationAmountCents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		raw         string
+		wantCents   int
+		wantErr     bool
+	}{
+		{name: "simple integer", raw: "50", wantCents: 5000, wantErr: false},
+		{name: "with dollar sign", raw: "$100", wantCents: 10000, wantErr: false},
+		{name: "with commas", raw: "1,000", wantCents: 100000, wantErr: false},
+		{name: "with dollar sign and commas", raw: "$1,500", wantCents: 150000, wantErr: false},
+		{name: "with whitespace", raw: "  25  ", wantCents: 2500, wantErr: false},
+		{name: "empty string", raw: "", wantCents: 0, wantErr: true},
+		{name: "whitespace only", raw: "   ", wantCents: 0, wantErr: true},
+		{name: "zero amount", raw: "0", wantCents: 0, wantErr: true},
+		{name: "negative amount", raw: "-10", wantCents: 0, wantErr: true},
+		{name: "non-numeric", raw: "abc", wantCents: 0, wantErr: true},
+		{name: "decimal value", raw: "25.50", wantCents: 0, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cents, err := parseDonationAmountCents(tt.raw)
+			if tt.wantErr {
+				if err == nil && cents > 0 {
+					t.Fatalf("parseDonationAmountCents(%q) = %d, nil; want error", tt.raw, cents)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDonationAmountCents(%q) unexpected error: %v", tt.raw, err)
+			}
+			if cents != tt.wantCents {
+				t.Fatalf("parseDonationAmountCents(%q) = %d, want %d", tt.raw, cents, tt.wantCents)
+			}
+		})
+	}
+}
+
+func TestDonationStatusLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   string
+		expected string
+	}{
+		{name: "finalized", status: "finalized", expected: "Payment Complete"},
+		{name: "failed", status: "failed", expected: "Payment Failed"},
+		{name: "canceled", status: "canceled", expected: "Payment Canceled"},
+		{name: "pending", status: "pending", expected: "Payment Processing"},
+		{name: "empty string", status: "", expected: "Payment Processing"},
+		{name: "unknown status", status: "refunded", expected: "Payment Processing"},
+		{name: "with whitespace", status: "  finalized  ", expected: "Payment Complete"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := donationStatusLabel(tt.status)
+			if actual != tt.expected {
+				t.Fatalf("donationStatusLabel(%q) = %q, want %q", tt.status, actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDonationStatusTitle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		status    string
+		ownerName string
+		expected  string
+	}{
+		{name: "finalized", status: "finalized", ownerName: "John", expected: "Thank you for supporting John"},
+		{name: "failed", status: "failed", ownerName: "Jane", expected: "We couldn't complete your donation"},
+		{name: "canceled", status: "canceled", ownerName: "Bob", expected: "Donation was canceled"},
+		{name: "pending", status: "pending", ownerName: "Alice", expected: "Thanks — we captured your donation"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := donationStatusTitle(tt.status, tt.ownerName)
+			if actual != tt.expected {
+				t.Fatalf("donationStatusTitle(%q, %q) = %q, want %q", tt.status, tt.ownerName, actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDonationStatusDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   string
+		contains string
+	}{
+		{name: "finalized", status: "finalized", contains: "finalized and has been applied"},
+		{name: "failed", status: "failed", contains: "did not complete"},
+		{name: "canceled", status: "canceled", contains: "exited checkout"},
+		{name: "pending", status: "pending", contains: "still processing"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := donationStatusDescription(tt.status)
+			if len(actual) == 0 {
+				t.Fatalf("donationStatusDescription(%q) returned empty string", tt.status)
+			}
+		})
+	}
+}
+
+func TestDonationStatusGuidance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "finalized", status: "finalized"},
+		{name: "failed", status: "failed"},
+		{name: "canceled", status: "canceled"},
+		{name: "pending", status: "pending"},
+		{name: "unknown", status: "something_else"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := donationStatusGuidance(tt.status)
+			if len(actual) == 0 {
+				t.Fatalf("donationStatusGuidance(%q) returned empty string", tt.status)
+			}
+		})
+	}
+}

--- a/internal/server/onboarding_donor.go
+++ b/internal/server/onboarding_donor.go
@@ -192,6 +192,22 @@ func (s *Service) handlePostOnboardingDonorPreferences(w http.ResponseWriter, r 
 	http.Redirect(w, r, s.route(RouteOnboardingDonorConfirmation, nil), http.StatusSeeOther)
 }
 
+func (s *Service) handlePostOnboardingDonorSkip(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	donorType := string(types.UserTypeDonor)
+	err := s.setUserType(ctx, donorType)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to set user type for donor skip")
+		s.internalServerError(w)
+		return
+	}
+
+	s.updateAuthUserTypeCookie(w, r, donorType)
+
+	http.Redirect(w, r, s.route(RouteBrowse, nil), http.StatusSeeOther)
+}
+
 func (s *Service) handleGetOnboardingDonorConfirmation(w http.ResponseWriter, r *http.Request) {
 	data := &types.DonorConfirmationPageData{BasePageData: types.BasePageData{Title: "Donor Onboarding Complete"}}
 

--- a/internal/server/pages.go
+++ b/internal/server/pages.go
@@ -39,15 +39,43 @@ func (s *Service) handleHome(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var recommendedNeeds []*types.BrowseNeedCard
+	if session, ok := sessionFromRequest(r); ok && session.UserType == string(types.UserTypeDonor) {
+		assignments, err := s.donorPreferenceAssignRepo.AssignmentsByUserID(ctx, session.UserID)
+		if err != nil {
+			s.logger.WithError(err).Warn("failed to load donor preference categories for home recommendations")
+		} else if len(assignments) > 0 {
+			catIDs := make(map[string]bool, len(assignments))
+			for _, a := range assignments {
+				catIDs[a.CategoryID] = true
+			}
+			recFilters := types.BrowseFilters{
+				CategoryIDs: catIDs,
+				FundingMax:  100,
+				ViewMode:    "grid",
+				SortBy:      "urgency",
+				Page:        1,
+				PageSize:    4,
+			}
+			recData, err := s.buildBrowseResultsPageData(ctx, recFilters)
+			if err != nil {
+				s.logger.WithError(err).Warn("failed to build recommended needs for home")
+			} else {
+				recommendedNeeds = recData.Needs
+			}
+		}
+	}
+
 	data := &types.HomePageData{
-		BasePageData: types.BasePageData{Title: ""},
-		Notice:       r.URL.Query().Get("notice"),
-		Error:        r.URL.Query().Get("error"),
-		FeaturedNeed: featuredNeed,
-		Needs:        featuredNeeds,
-		Categories:   s.buildHomeCategories(ctx),
-		Stats:        s.buildHomeStats(ctx),
-		Steps:        getSteps(),
+		BasePageData:     types.BasePageData{Title: ""},
+		Notice:           r.URL.Query().Get("notice"),
+		Error:            r.URL.Query().Get("error"),
+		FeaturedNeed:     featuredNeed,
+		Needs:            featuredNeeds,
+		RecommendedNeeds: recommendedNeeds,
+		Categories:       s.buildHomeCategories(ctx),
+		Stats:            s.buildHomeStats(ctx),
+		Steps:            getSteps(),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -338,6 +366,22 @@ func (s *Service) handleBrowse(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	filters := parseBrowseFilters(r.URL.Query())
 
+	preferencesApplied := false
+	showAll := r.URL.Query().Get("show_all") == "1"
+	if len(filters.CategoryIDs) == 0 && !showAll {
+		if session, ok := sessionFromRequest(r); ok && session.UserType == string(types.UserTypeDonor) {
+			assignments, err := s.donorPreferenceAssignRepo.AssignmentsByUserID(ctx, session.UserID)
+			if err != nil {
+				s.logger.WithError(err).Warn("failed to load donor preference categories for browse")
+			} else if len(assignments) > 0 {
+				for _, a := range assignments {
+					filters.CategoryIDs[a.CategoryID] = true
+				}
+				preferencesApplied = true
+			}
+		}
+	}
+
 	if isHXRequest(r) {
 		data, err := s.buildBrowseResultsPageData(ctx, filters)
 		if err != nil {
@@ -347,6 +391,7 @@ func (s *Service) handleBrowse(w http.ResponseWriter, r *http.Request) {
 		}
 
 		data.BasePageData = types.BasePageData{Title: "Browse Needs"}
+		data.PreferencesApplied = preferencesApplied
 		data.LoadResultsOnRender = false
 		data.ShowResultsSkeletons = false
 
@@ -376,6 +421,7 @@ func (s *Service) handleBrowse(w http.ResponseWriter, r *http.Request) {
 		Categories:           categories,
 		Cities:               cityOptions,
 		Filters:              filters,
+		PreferencesApplied:   preferencesApplied,
 		LoadResultsOnRender:  true,
 		ShowResultsSkeletons: true,
 	}

--- a/internal/server/pages_test.go
+++ b/internal/server/pages_test.go
@@ -1,0 +1,299 @@
+package server
+
+import (
+	"net/url"
+	"testing"
+
+	"christjesus/pkg/types"
+)
+
+func TestParseBrowseFilters_EmptyQuery(t *testing.T) {
+	t.Parallel()
+
+	filters := parseBrowseFilters(url.Values{})
+
+	if len(filters.CategoryIDs) != 0 {
+		t.Fatalf("parseBrowseFilters(empty) CategoryIDs = %v, want empty map", filters.CategoryIDs)
+	}
+	if filters.Search != "" {
+		t.Fatalf("parseBrowseFilters(empty) Search = %q, want empty", filters.Search)
+	}
+	if filters.City != "" {
+		t.Fatalf("parseBrowseFilters(empty) City = %q, want empty", filters.City)
+	}
+	if filters.FundingMax != 100 {
+		t.Fatalf("parseBrowseFilters(empty) FundingMax = %d, want 100", filters.FundingMax)
+	}
+	if filters.ViewMode != "grid" {
+		t.Fatalf("parseBrowseFilters(empty) ViewMode = %q, want grid", filters.ViewMode)
+	}
+	if filters.SortBy != "urgency" {
+		t.Fatalf("parseBrowseFilters(empty) SortBy = %q, want urgency", filters.SortBy)
+	}
+	if filters.Page != 1 {
+		t.Fatalf("parseBrowseFilters(empty) Page = %d, want 1", filters.Page)
+	}
+	if filters.PageSize != browseDefaultPageSize {
+		t.Fatalf("parseBrowseFilters(empty) PageSize = %d, want %d", filters.PageSize, browseDefaultPageSize)
+	}
+}
+
+func TestParseBrowseFilters_WithCategories(t *testing.T) {
+	t.Parallel()
+
+	query := url.Values{}
+	query.Add("category", "cat_001")
+	query.Add("category", "cat_002")
+	query.Add("category", "cat_003")
+
+	filters := parseBrowseFilters(query)
+
+	if len(filters.CategoryIDs) != 3 {
+		t.Fatalf("parseBrowseFilters() CategoryIDs length = %d, want 3", len(filters.CategoryIDs))
+	}
+	for _, id := range []string{"cat_001", "cat_002", "cat_003"} {
+		if !filters.CategoryIDs[id] {
+			t.Fatalf("parseBrowseFilters() CategoryIDs missing %q", id)
+		}
+	}
+}
+
+func TestParseBrowseFilters_EmptyCategoriesIgnored(t *testing.T) {
+	t.Parallel()
+
+	query := url.Values{}
+	query.Add("category", "cat_001")
+	query.Add("category", "")
+	query.Add("category", "   ")
+
+	filters := parseBrowseFilters(query)
+
+	if len(filters.CategoryIDs) != 1 {
+		t.Fatalf("parseBrowseFilters() CategoryIDs length = %d, want 1 (got %v)", len(filters.CategoryIDs), filters.CategoryIDs)
+	}
+	if !filters.CategoryIDs["cat_001"] {
+		t.Fatal("parseBrowseFilters() CategoryIDs should contain cat_001")
+	}
+}
+
+func TestParseBrowseFilters_FundingMax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      string
+		expected int
+	}{
+		{name: "valid 50", raw: "50", expected: 50},
+		{name: "zero", raw: "0", expected: 0},
+		{name: "negative clamped to 0", raw: "-10", expected: 0},
+		{name: "above 100 clamped", raw: "150", expected: 100},
+		{name: "exactly 100", raw: "100", expected: 100},
+		{name: "non-numeric falls back to 100", raw: "abc", expected: 100},
+		{name: "empty falls back to 100", raw: "", expected: 100},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			query := url.Values{}
+			if tt.raw != "" {
+				query.Set("funding_max", tt.raw)
+			}
+
+			filters := parseBrowseFilters(query)
+			if filters.FundingMax != tt.expected {
+				t.Fatalf("parseBrowseFilters(funding_max=%q) FundingMax = %d, want %d", tt.raw, filters.FundingMax, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseBrowseFilters_ViewMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{name: "list mode", raw: "list", expected: "list"},
+		{name: "list uppercase", raw: "LIST", expected: "list"},
+		{name: "grid mode", raw: "grid", expected: "grid"},
+		{name: "unknown defaults to grid", raw: "table", expected: "grid"},
+		{name: "empty defaults to grid", raw: "", expected: "grid"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			query := url.Values{}
+			if tt.raw != "" {
+				query.Set("view", tt.raw)
+			}
+
+			filters := parseBrowseFilters(query)
+			if filters.ViewMode != tt.expected {
+				t.Fatalf("parseBrowseFilters(view=%q) ViewMode = %q, want %q", tt.raw, filters.ViewMode, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseBrowseFilters_SortBy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{name: "newest", raw: "newest", expected: "newest"},
+		{name: "closest", raw: "closest", expected: "closest"},
+		{name: "nearest", raw: "nearest", expected: "nearest"},
+		{name: "urgency", raw: "urgency", expected: "urgency"},
+		{name: "uppercase newest", raw: "NEWEST", expected: "newest"},
+		{name: "unknown defaults to urgency", raw: "random", expected: "urgency"},
+		{name: "empty defaults to urgency", raw: "", expected: "urgency"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			query := url.Values{}
+			if tt.raw != "" {
+				query.Set("sort", tt.raw)
+			}
+
+			filters := parseBrowseFilters(query)
+			if filters.SortBy != tt.expected {
+				t.Fatalf("parseBrowseFilters(sort=%q) SortBy = %q, want %q", tt.raw, filters.SortBy, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseBrowseFilters_SearchAndCity(t *testing.T) {
+	t.Parallel()
+
+	query := url.Values{}
+	query.Set("search", "  housing  ")
+	query.Set("city", "  Nashville  ")
+
+	filters := parseBrowseFilters(query)
+
+	if filters.Search != "housing" {
+		t.Fatalf("parseBrowseFilters() Search = %q, want %q", filters.Search, "housing")
+	}
+	if filters.City != "Nashville" {
+		t.Fatalf("parseBrowseFilters() City = %q, want %q", filters.City, "Nashville")
+	}
+}
+
+func TestParseBrowseFilters_PageParsing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      string
+		expected int
+	}{
+		{name: "valid page 3", raw: "3", expected: 3},
+		{name: "page 1", raw: "1", expected: 1},
+		{name: "zero falls back to 1", raw: "0", expected: 1},
+		{name: "negative falls back to 1", raw: "-1", expected: 1},
+		{name: "non-numeric falls back to 1", raw: "abc", expected: 1},
+		{name: "empty falls back to 1", raw: "", expected: 1},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			query := url.Values{}
+			if tt.raw != "" {
+				query.Set("page", tt.raw)
+			}
+
+			filters := parseBrowseFilters(query)
+			if filters.Page != tt.expected {
+				t.Fatalf("parseBrowseFilters(page=%q) Page = %d, want %d", tt.raw, filters.Page, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBrowseUrgency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		status            types.NeedStatus
+		amountNeededCents int
+		amountRaisedCents int
+		expectedLabel     string
+	}{
+		{name: "zero needed returns LOW", status: types.NeedStatusActive, amountNeededCents: 0, amountRaisedCents: 0, expectedLabel: "LOW"},
+		{name: "under 35 percent is HIGH", status: types.NeedStatusActive, amountNeededCents: 10000, amountRaisedCents: 3000, expectedLabel: "HIGH"},
+		{name: "exactly 35 percent is MEDIUM", status: types.NeedStatusActive, amountNeededCents: 10000, amountRaisedCents: 3500, expectedLabel: "MEDIUM"},
+		{name: "under 70 percent is MEDIUM", status: types.NeedStatusActive, amountNeededCents: 10000, amountRaisedCents: 6900, expectedLabel: "MEDIUM"},
+		{name: "70 percent or above is LOW", status: types.NeedStatusActive, amountNeededCents: 10000, amountRaisedCents: 7000, expectedLabel: "LOW"},
+		{name: "fully funded is LOW", status: types.NeedStatusActive, amountNeededCents: 10000, amountRaisedCents: 10000, expectedLabel: "LOW"},
+		{name: "submitted status is URGENT", status: types.NeedStatusSubmitted, amountNeededCents: 10000, amountRaisedCents: 9000, expectedLabel: "URGENT"},
+		{name: "under review is URGENT", status: types.NeedStatusUnderReview, amountNeededCents: 10000, amountRaisedCents: 9000, expectedLabel: "URGENT"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			label, dotClass := browseUrgency(tt.status, tt.amountNeededCents, tt.amountRaisedCents)
+			if label != tt.expectedLabel {
+				t.Fatalf("browseUrgency() label = %q, want %q", label, tt.expectedLabel)
+			}
+			if dotClass == "" {
+				t.Fatal("browseUrgency() dotClass should not be empty")
+			}
+		})
+	}
+}
+
+func TestUserDisplayName(t *testing.T) {
+	t.Parallel()
+
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name     string
+		user     *types.User
+		expected string
+	}{
+		{name: "nil user", user: nil, expected: "Anonymous"},
+		{name: "empty user", user: &types.User{}, expected: "Anonymous"},
+		{name: "given name only", user: &types.User{GivenName: strPtr("John")}, expected: "John"},
+		{name: "family name only", user: &types.User{FamilyName: strPtr("Doe")}, expected: "Doe"},
+		{name: "full name", user: &types.User{GivenName: strPtr("John"), FamilyName: strPtr("Doe")}, expected: "John Doe"},
+		{name: "email fallback", user: &types.User{Email: strPtr("john@example.com")}, expected: "john"},
+		{name: "whitespace names fall to email", user: &types.User{GivenName: strPtr("  "), FamilyName: strPtr("  "), Email: strPtr("test@example.com")}, expected: "test"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := userDisplayName(tt.user)
+			if actual != tt.expected {
+				t.Fatalf("userDisplayName() = %q, want %q", actual, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -201,6 +201,16 @@ func (s *Service) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var impactStats types.DonorImpactStats
+	if userType == string(types.UserTypeDonor) {
+		stats, err := s.donationIntentRepo.DonorImpactStats(ctx, session.UserID)
+		if err != nil {
+			s.logger.WithError(err).WithField("user_id", session.UserID).Warn("failed to fetch donor impact stats for profile")
+		} else {
+			impactStats = stats
+		}
+	}
+
 	data := &types.ProfilePageData{
 		BasePageData:      types.BasePageData{Title: "My Profile"},
 		UserID:            session.UserID,
@@ -217,6 +227,7 @@ func (s *Service) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 		DonationSummaries: donationSummaries,
 		HasNeeds:          len(myNeeds) > 0,
 		HasDonations:      len(donationSummaries) > 0,
+		ImpactStats:       impactStats,
 	}
 
 	err = s.renderTemplate(w, r, "page.profile", data)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -53,6 +53,7 @@ const (
 
 	RouteOnboardingDonorWelcome      RouteName = "onboarding.donor.welcome"
 	RouteOnboardingDonorPreferences  RouteName = "onboarding.donor.preferences"
+	RouteOnboardingDonorSkip         RouteName = "onboarding.donor.skip"
 	RouteOnboardingDonorConfirmation RouteName = "onboarding.donor.confirmation"
 
 	RouteOnboardingSponsorIndividual   RouteName = "onboarding.sponsor.individual.welcome"
@@ -127,6 +128,7 @@ var routePatterns = map[RouteName]string{
 	RouteOnboardingHowWeServeYou:       "/onboarding/how-we-serve-you",
 	RouteOnboardingDonorWelcome:        "/onboarding/donor/welcome",
 	RouteOnboardingDonorPreferences:    "/onboarding/donor/preferences",
+	RouteOnboardingDonorSkip:           "/onboarding/donor/skip",
 	RouteOnboardingDonorConfirmation:   "/onboarding/donor/confirmation",
 	RouteOnboardingNeedWelcome:         "/onboarding/need/:needID/welcome",
 	RouteOnboardingNeedLocation:        "/onboarding/need/:needID/location",

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -44,6 +44,12 @@ func TestBuildRoute_SelectedRouteShapes(t *testing.T) {
 			},
 			expected: "/onboarding/need/need_123/documents/doc_456/delete",
 		},
+		{
+			name:     "donor skip no parameters",
+			route:    RouteOnboardingDonorSkip,
+			params:   nil,
+			expected: "/onboarding/donor/skip",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -243,6 +243,7 @@ func (s *Service) buildRouter(r *flow.Mux, csrfKey []byte) {
 			r.HandleFunc(RoutePattern(RouteOnboardingDonorWelcome), s.handleGetOnboardingDonorWelcome, http.MethodGet)
 			r.HandleFunc(RoutePattern(RouteOnboardingDonorPreferences), s.handleGetOnboardingDonorPreferences, http.MethodGet)
 			r.HandleFunc(RoutePattern(RouteOnboardingDonorPreferences), s.handlePostOnboardingDonorPreferences, http.MethodPost)
+			r.HandleFunc(RoutePattern(RouteOnboardingDonorSkip), s.handlePostOnboardingDonorSkip, http.MethodPost)
 			r.HandleFunc(RoutePattern(RouteOnboardingDonorConfirmation), s.handleGetOnboardingDonorConfirmation, http.MethodGet)
 
 			r.HandleFunc(RoutePattern(RouteNeedDonate), s.handleGetNeedDonate, http.MethodGet)
@@ -336,6 +337,15 @@ func templateFuncMap() template.FuncMap {
 	}
 
 	return template.FuncMap{
+		"formatCents": func(cents any) string {
+			c := toInt64(cents)
+			if c < 0 {
+				c = 0
+			}
+			dollars := c / 100
+			remainder := c % 100
+			return fmt.Sprintf("%d.%02d", dollars, remainder)
+		},
 		"div": func(a, b any) int64 {
 			a64 := toInt64(a)
 			b64 := toInt64(b)

--- a/internal/server/templates/pages/browse.html
+++ b/internal/server/templates/pages/browse.html
@@ -66,6 +66,13 @@
       </div>
     </div>
     {{else}}
+      {{if .PreferencesApplied}}
+      <div class="rounded-md border border-[color:var(--cj-accent)]/30 bg-[color:var(--cj-accent)]/10 px-4 py-2 text-sm text-foreground">
+        Filtered by your preferences.
+        <a href="{{routeq "browse" nil (dict "show_all" "1")}}" class="ml-1 font-medium text-[color:var(--cj-primary)] hover:underline">Show all</a>
+      </div>
+      {{end}}
+
       <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div class="text-sm text-muted-foreground">
           Showing {{len .Needs}} of {{.TotalNeeds}} needs

--- a/internal/server/templates/pages/home.html
+++ b/internal/server/templates/pages/home.html
@@ -71,6 +71,26 @@
     </div>
   </section>
 
+  {{if .RecommendedNeeds}}
+  <!-- Section: Recommended for You -->
+  <section class="bg-amber-50/50 py-12">
+    <div class="mx-auto w-full max-w-6xl px-4 md:px-6">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 class="text-2xl font-semibold text-foreground">Recommended for you</h2>
+          <p class="mt-1 text-sm text-muted-foreground">Based on your saved category preferences.</p>
+        </div>
+        <a href="{{route "browse" nil}}" class="text-sm text-muted-foreground hover:text-foreground">View all</a>
+      </div>
+      <div class="mt-6 grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        {{range .RecommendedNeeds}}
+        {{template "component.need.card" .}}
+        {{end}}
+      </div>
+    </div>
+  </section>
+  {{end}}
+
   <!-- Section 3: Need Categories -->
   <section class="bg-slate-50 py-12">
     <div class="mx-auto w-full max-w-6xl px-4 md:px-6">

--- a/internal/server/templates/pages/need-donate-confirmation.html
+++ b/internal/server/templates/pages/need-donate-confirmation.html
@@ -39,6 +39,18 @@
       </a>
     </div>
   </div>
+
+  {{if .RelatedNeeds}}
+  <div class="mt-8">
+    <h2 class="text-xl font-semibold text-foreground">Needs like this</h2>
+    <p class="mt-1 text-sm text-muted-foreground">Other needs in the same category that could use your support.</p>
+    <div class="mt-4 grid gap-6 md:grid-cols-3">
+      {{range .RelatedNeeds}}
+      {{template "component.need.card" .}}
+      {{end}}
+    </div>
+  </div>
+  {{end}}
 </div>
 
 {{template "footer" .}}

--- a/internal/server/templates/pages/need-donate.html
+++ b/internal/server/templates/pages/need-donate.html
@@ -20,7 +20,7 @@
       <p class="mt-6 text-sm text-muted-foreground">{{derefOr .ShortDescription "Support this neighbor by learning more and contributing if you can."}}</p>
 
       <div class="mt-8 rounded-lg border border-border bg-muted/30 px-5 py-4 text-sm text-muted-foreground">
-        Goal: ${{div .AmountNeededCents 100}} • Raised: ${{div .AmountRaisedCents 100}}
+        Goal: ${{formatCents .AmountNeededCents}} • Raised: ${{formatCents .AmountRaisedCents}}
       </div>
     </section>
 
@@ -30,6 +30,11 @@
 
       <form method="post" action="{{route "need.donate" (dict "needID" .NeedID)}}" class="mt-7 space-y-6">
         {{.CSRFField}}
+        {{if gt .RemainingCents 0}}
+        <div class="rounded-lg border border-[color:var(--cj-accent)]/30 bg-[color:var(--cj-accent)]/10 px-4 py-3 text-sm font-medium text-foreground">
+          Only ${{formatCents .RemainingCents}} to fully fund this need!
+        </div>
+        {{end}}
         <div class="grid grid-cols-2 gap-3">
           {{range .PresetAmounts}}
           <label class="block cursor-pointer">

--- a/internal/server/templates/pages/onboarding/donor/confirmation.html
+++ b/internal/server/templates/pages/onboarding/donor/confirmation.html
@@ -2,6 +2,16 @@
 {{template "header" .}}
 
 <div class="mx-auto w-full max-w-3xl px-4 py-10 md:px-6">
+  <div class="mb-6">
+    <div class="flex items-center justify-between text-sm text-muted-foreground">
+      <span class="font-medium text-[color:var(--cj-accent)]">Step 3 of 3</span>
+      <span>Complete</span>
+    </div>
+    <div class="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+      <div class="h-full rounded-full bg-[color:var(--cj-accent)]" style="width: 100%"></div>
+    </div>
+  </div>
+
   <div class="flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
     <div class="space-y-6 px-6 text-center">
       <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--cj-success)]/10">

--- a/internal/server/templates/pages/onboarding/donor/preferences.html
+++ b/internal/server/templates/pages/onboarding/donor/preferences.html
@@ -2,6 +2,16 @@
 {{template "header" .}}
 
 <div class="mx-auto w-full max-w-5xl px-4 py-10 md:px-6">
+  <div class="mb-6">
+    <div class="flex items-center justify-between text-sm text-muted-foreground">
+      <span class="font-medium text-[color:var(--cj-accent)]">Step 2 of 3</span>
+      <span>Preferences</span>
+    </div>
+    <div class="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+      <div class="h-full rounded-full bg-[color:var(--cj-accent)]" style="width: 66%"></div>
+    </div>
+  </div>
+
   <div class="mb-8 flex flex-col gap-4">
     <div>
       <p class="text-sm font-semibold uppercase tracking-wide text-[color:var(--cj-accent)]">Donor onboarding</p>
@@ -88,10 +98,19 @@
       class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium transition-all hover:bg-accent hover:text-accent-foreground">
       Back
     </a>
-    <button type="submit" form="donor-preferences-form"
-      class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-all hover:bg-[color:var(--cj-primary)]/90">
-      Complete Setup
-    </button>
+    <div class="flex items-center gap-3">
+      <form method="post" action="{{route "onboarding.donor.skip" nil}}">
+        {{.CSRFField}}
+        <button type="submit"
+          class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium text-muted-foreground transition-all hover:bg-accent hover:text-accent-foreground">
+          Skip for now
+        </button>
+      </form>
+      <button type="submit" form="donor-preferences-form"
+        class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-all hover:bg-[color:var(--cj-primary)]/90">
+        Complete Setup
+      </button>
+    </div>
   </div>
 </div>
 

--- a/internal/server/templates/pages/onboarding/donor/welcome.html
+++ b/internal/server/templates/pages/onboarding/donor/welcome.html
@@ -2,6 +2,16 @@
 {{template "header" .}}
 
 <div class="mx-auto w-full max-w-5xl px-4 py-10 md:px-6">
+  <div class="mb-6">
+    <div class="flex items-center justify-between text-sm text-muted-foreground">
+      <span class="font-medium text-[color:var(--cj-accent)]">Step 1 of 3</span>
+      <span>Welcome</span>
+    </div>
+    <div class="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+      <div class="h-full rounded-full bg-[color:var(--cj-accent)]" style="width: 33%"></div>
+    </div>
+  </div>
+
   <div class="mb-8 flex flex-col gap-4">
     <div>
       <p class="text-sm font-semibold uppercase tracking-wide text-[color:var(--cj-accent)]">Donor onboarding</p>
@@ -42,7 +52,13 @@
   </div>
 
   <div class="mt-6 flex items-center justify-between">
-    <div></div>
+    <form method="post" action="{{route "onboarding.donor.skip" nil}}">
+      {{.CSRFField}}
+      <button type="submit"
+        class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium text-muted-foreground transition-all hover:bg-accent hover:text-accent-foreground">
+        Skip for now
+      </button>
+    </form>
     <a href="{{route "onboarding.donor.preferences" nil}}"
       class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-all hover:bg-[color:var(--cj-primary)]/90">
       Set up my preferences

--- a/internal/server/templates/pages/profile.html
+++ b/internal/server/templates/pages/profile.html
@@ -111,6 +111,24 @@
       {{end}}
 
       {{if eq .UserType "donor"}}
+      <div class="rounded-xl border bg-background p-6">
+        <h2 class="text-xl font-semibold text-foreground">Your Giving Impact</h2>
+        <div class="mt-4 grid gap-4 sm:grid-cols-3">
+          <div class="rounded-lg border border-border bg-muted/30 px-4 py-4 text-center">
+            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Total Given</p>
+            <p class="mt-1 text-2xl font-semibold text-foreground">${{div .ImpactStats.TotalGivenCents 100}}</p>
+          </div>
+          <div class="rounded-lg border border-border bg-muted/30 px-4 py-4 text-center">
+            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Needs Supported</p>
+            <p class="mt-1 text-2xl font-semibold text-foreground">{{.ImpactStats.NeedsSupported}}</p>
+          </div>
+          <div class="rounded-lg border border-border bg-muted/30 px-4 py-4 text-center">
+            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Needs Fully Funded</p>
+            <p class="mt-1 text-2xl font-semibold text-foreground">{{.ImpactStats.NeedsFunded}}</p>
+          </div>
+        </div>
+      </div>
+
       <div id="donations" class="rounded-xl border bg-background p-6">
         <h2 class="text-xl font-semibold text-foreground">Donation History</h2>
         {{if .HasDonations}}

--- a/internal/store/donation_intent.go
+++ b/internal/store/donation_intent.go
@@ -362,6 +362,47 @@ func (r *DonationIntentRepository) DonationIntentsByDonorUserID(ctx context.Cont
 	return intents, nil
 }
 
+func (r *DonationIntentRepository) DonorImpactStats(ctx context.Context, donorUserID string) (types.DonorImpactStats, error) {
+	query := fmt.Sprintf(`
+		WITH donor_finalized AS (
+			SELECT need_id, amount_cents
+			FROM %s
+			WHERE donor_user_id = $1 AND payment_status = $2
+		),
+		totals AS (
+			SELECT
+				COALESCE(SUM(amount_cents), 0) AS total_given_cents,
+				COUNT(DISTINCT need_id) AS needs_supported
+			FROM donor_finalized
+		),
+		funded AS (
+			SELECT COUNT(*) AS needs_funded
+			FROM (
+				SELECT n.id
+				FROM %s n
+				WHERE n.deleted_at IS NULL
+				  AND EXISTS (SELECT 1 FROM donor_finalized df WHERE df.need_id = n.id)
+				  AND n.amount_needed_cents > 0
+				  AND n.amount_raised_cents >= n.amount_needed_cents
+			) funded_needs
+		)
+		SELECT totals.total_given_cents, totals.needs_supported, funded.needs_funded
+		FROM totals, funded
+	`, donationIntentTableName, needTableName)
+
+	stats := types.DonorImpactStats{}
+	err := r.pool.QueryRow(ctx, query, donorUserID, types.DonationPaymentStatusFinalized).Scan(
+		&stats.TotalGivenCents,
+		&stats.NeedsSupported,
+		&stats.NeedsFunded,
+	)
+	if err != nil {
+		return types.DonorImpactStats{}, fmt.Errorf("failed to fetch donor impact stats: %w", err)
+	}
+
+	return stats, nil
+}
+
 func (r *DonationIntentRepository) HomeImpactStats(ctx context.Context) (types.StatsData, error) {
 	query := fmt.Sprintf(`
 		WITH finalized AS (

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -375,6 +375,43 @@ func (r *NeedRepository) AdminExplorerNeedsCountByStatus(ctx context.Context) (m
 	return counts, nil
 }
 
+func (r *NeedRepository) NeedsByCategoryExcluding(ctx context.Context, categoryID, excludeNeedID string, limit int) ([]*types.Need, error) {
+	if limit <= 0 {
+		limit = 3
+	}
+
+	cols := make([]string, len(needColumns))
+	for i, c := range needColumns {
+		cols[i] = "n." + c
+	}
+
+	qb := psql().Select(cols...).
+		From(browseFromClause).
+		LeftJoin(browseJoinPrimaryCategory).
+		Where(sq.Eq{"n.status": []types.NeedStatus{types.NeedStatusActive, types.NeedStatusFunded}}).
+		Where(sq.Eq{"n.deleted_at": nil}).
+		Where(sq.Eq{"nca.category_id": categoryID}).
+		Where(sq.NotEq{"n.id": excludeNeedID}).
+		OrderBy("n.created_at DESC").
+		Limit(uint64(limit))
+
+	query, args, err := qb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate needs by category excluding query: %w", err)
+	}
+
+	needs := make([]*types.Need, 0)
+	err = pgxscan.Select(ctx, r.pool, &needs, query, args...)
+	if err != nil {
+		if pgxscan.NotFound(err) {
+			return needs, nil
+		}
+		return nil, fmt.Errorf("failed to fetch needs by category excluding: %w", err)
+	}
+
+	return needs, nil
+}
+
 func (r *NeedRepository) LatestNeeds(ctx context.Context, limit int) ([]*types.Need, error) {
 	if limit <= 0 {
 		limit = 5

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -38,13 +38,14 @@ func (d *BasePageData) SetCSRFField(field template.HTML) {
 
 type HomePageData struct {
 	BasePageData
-	Notice       string
-	Error        string
-	FeaturedNeed *BrowseNeedCard
-	Needs        []*BrowseNeedCard
-	Categories   []CategoryData
-	Stats        StatsData
-	Steps        []StepData
+	Notice           string
+	Error            string
+	FeaturedNeed     *BrowseNeedCard
+	Needs            []*BrowseNeedCard
+	RecommendedNeeds []*BrowseNeedCard
+	Categories       []CategoryData
+	Stats            StatsData
+	Steps            []StepData
 }
 
 type BrowsePageData struct {
@@ -53,6 +54,7 @@ type BrowsePageData struct {
 	Categories           []*NeedCategory
 	Cities               []string
 	Filters              BrowseFilters
+	PreferencesApplied   bool
 	LoadResultsOnRender  bool
 	ShowResultsSkeletons bool
 	Page                 int
@@ -141,6 +143,7 @@ type NeedDonatePageData struct {
 	ShortDescription  *string
 	AmountNeededCents int
 	AmountRaisedCents int
+	RemainingCents    int
 	SelectedPreset    int
 	CustomAmount      string
 	PrivateMessage    string
@@ -157,6 +160,7 @@ type NeedDonateConfirmationPageData struct {
 	AmountCents        int
 	IsAnonymous        bool
 	PrimaryCategory    string
+	PrimaryCategoryID  string
 	PaymentStatus      string
 	StatusLabel        string
 	StatusTitle        string
@@ -165,6 +169,7 @@ type NeedDonateConfirmationPageData struct {
 	ShowRetryCTA       bool
 	ShowReceiptDetails bool
 	DonationDate       string
+	RelatedNeeds       []*BrowseNeedCard
 }
 
 type LoginPageData struct {
@@ -326,6 +331,12 @@ type ProfileNavItem struct {
 	ShowItem bool
 }
 
+type DonorImpactStats struct {
+	TotalGivenCents int
+	NeedsSupported  int
+	NeedsFunded     int
+}
+
 type ProfilePageData struct {
 	BasePageData
 	UserID            string
@@ -342,6 +353,7 @@ type ProfilePageData struct {
 	DonationSummaries []ProfileDonationSummary
 	HasNeeds          bool
 	HasDonations      bool
+	ImpactStats       DonorImpactStats
 }
 
 type ProfileNeedSummary struct {


### PR DESCRIPTION
This PR touches the full donor journey across 20 files in `internal/server/`, `internal/store/`, and `pkg/types/`. On the onboarding side, `handlePostOnboardingDonorSkip` in `onboarding_donor.go` gives donors a way to bypass preference setup and land directly on `/browse` — the route `RouteOnboardingDonorSkip` and its wiring in `server.go` support that. The three onboarding templates (`welcome.html`, `preferences.html`, `confirmation.html`) now render a step-progress bar so donors know where they are in the flow. In the browse and home pages, `handleBrowse` in `pages.go` auto-applies saved category preferences when no explicit filter is selected (with a `?show_all=1` escape hatch), and `handleHome` builds a "Recommended for you" card grid by querying the donor's `donorPreferenceAssignRepo` categories and feeding them into `buildBrowseResultsPageData` with a four-card limit.

On the donation side, `buildNeedDonatePageData` in `donate.go` now computes `RemainingCents` and passes it through a new `buildSmartPresets` function that prepends a "cover the remaining balance" dollar amount to the standard preset buttons — the template shows a contextual "Only $X.XX to fully fund this need!" banner when there is a gap. The confirmation page (`handleGetNeedDonateConfirmation`) pulls the need's primary category via `GetAssignmentsByNeedID`, then calls `NeedsByCategoryExcluding` (new method in `store/need.go`) to surface up to three related needs in the same category. A `formatCents` template helper in `server.go` replaces the old integer `div` approach so dollar-and-cent values render correctly across the donate and confirmation templates. The profile page (`handleGetProfile` in `profile.go`) now calls `DonorImpactStats` (new CTE query in `store/donation_intent.go`) to display total given, needs supported, and needs fully funded in a three-column stats card.

The design intent was to keep every enhancement non-blocking: category lookups, related-needs queries, and impact-stats fetches all log warnings and degrade gracefully so no single failure can break a page load. Smart presets and the remaining-balance banner are computed server-side to avoid client-side JS complexity, and the "skip" flow avoids forcing donors into a preferences funnel they might abandon. Test coverage was added in `donate_test.go` (table tests for `buildSmartPresets`, `parseDonationAmountCents`, and the status-label family of functions) and `pages_test.go` (full coverage for `parseBrowseFilters`, `browseUrgency`, and `userDisplayName`), plus a route-shape assertion for the new skip endpoint in `routes_test.go` — all tests pass locally with `just test` and no panics surfaced during manual walkthroughs of each flow.

Closes https://github.com/ddouglas/christjesus/issues/45