### PR TITLE
feat: integrate USPS address validation API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ export COGNITO_ISSUER_URL=<terraform-output>
 export STRIPE_SECRET_KEY=<sk_test_...>
 export STRIPE_PUBLISHABLE_KEY=<pk_test_...>
 export STRIPE_WEBHOOK_SECRET=<whsec_...>
+
+export USPS_CONSUMER_KEY=<usps-consumer-key>
+export USPS_CONSUMER_SECRET=<usps-consumer-secret>

--- a/cmd/christjesus/serve.go
+++ b/cmd/christjesus/serve.go
@@ -14,6 +14,7 @@ import (
 	"christjesus/internal/db"
 	"christjesus/internal/server"
 	"christjesus/internal/store"
+	"christjesus/internal/usps"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -97,11 +98,17 @@ func serve(cCtx *cli.Context) error {
 		return fmt.Errorf("failed to register supabase jwk with cache: %w", err)
 	}
 
+	var uspsClient *usps.Client
+	if config.USPSConsumerKey != "" && config.USPSConsumerSecret != "" {
+		uspsClient = usps.NewClient(config.USPSConsumerKey, config.USPSConsumerSecret)
+	}
+
 	srv, err := server.New(server.Options{
 		Config:                      config,
 		Logger:                      logger,
 		S3Client:                    s3Client,
 		StripeClient:                stripeClient,
+		USPSClient:                  uspsClient,
 		NeedsRepo:                   needsRepo,
 		ProgressRepo:                progressRepo,
 		CategoryRepo:                categoryRepo,

--- a/cmd/christjesus/serve.go
+++ b/cmd/christjesus/serve.go
@@ -98,10 +98,7 @@ func serve(cCtx *cli.Context) error {
 		return fmt.Errorf("failed to register supabase jwk with cache: %w", err)
 	}
 
-	var uspsClient *usps.Client
-	if config.USPSConsumerKey != "" && config.USPSConsumerSecret != "" {
-		uspsClient = usps.NewClient(config.USPSConsumerKey, config.USPSConsumerSecret)
-	}
+	uspsClient := usps.NewClient(config.USPSConsumerKey, config.USPSConsumerSecret)
 
 	srv, err := server.New(server.Options{
 		Config:                      config,

--- a/docs/usps/addresses-v3r2_3.yaml
+++ b/docs/usps/addresses-v3r2_3.yaml
@@ -1,0 +1,867 @@
+openapi: 3.0.1
+info:
+  title: Addresses
+  description: |
+    Contact Us: [USPS API Support](https://emailus.usps.com/s/usps-APIs) | [Terms of Service](https://about.usps.com/termsofuse.htm)
+    
+    The Addresses API validates and corrects address information to improve package delivery service and pricing. This suite of APIs provides different utilities for addressing components. The ZIP Code&#8482; lookup finds valid ZIP Code&#8482;(s) for a City and State. The City/State lookup provides the valid cities and states for a provided ZIP Code&#8482;. The Address Standardization API validates and standardizes USPS&#174; domestic addresses, city and state names, and ZIP Code&#8482; in accordance with USPS&#174; addressing standards. The USPS&#174; address standard includes the ZIP + 4&#174;, signifying a USPS&#174; delivery point, given a street address, a city and a state.
+    
+  version: 3.2.2
+servers:
+  - url: https://apis.usps.com/addresses/v3
+    description: Production Environment Endpoint
+  - url: https://apis-tem.usps.com/addresses/v3
+    description: Testing Environment Endpoint
+paths:
+  /address:
+    get:
+      tags:
+        - Resources
+      summary: Returns the best standardized address for a given address.
+      description: |-
+        Standardizes street addresses including city and street abbreviations as well as providing missing information such as ZIP Code&#8482; and ZIP + 4&#174;.
+
+        Must specify a street address, a state, and either a city or a ZIP Code&#8482;.
+      operationId: get-address
+      parameters:
+        - name: firm
+          in: query
+          description: "Firm/business corresponding to the address."
+          schema:
+            type: string
+            maxLength: 50
+            minLength: 0
+        - name: streetAddress
+          in: query
+          description: The number of a building along with the name of the road or street on which it is located.
+          required: true
+          schema:
+            type: string
+        - name: secondaryAddress
+          in: query
+          description: "The secondary unit designator, such as apartment(APT) or suite(STE) number, defining the exact location of the address within a building.  For more information please see [Postal Explorer](https://pe.usps.com/text/pub28/28c2_003.htm)."
+          required: false
+          schema:
+            type: string
+        - name: city
+          in: query
+          description: This is the city name of the address.
+          required: false
+          schema:
+            type: string
+        - name: state
+          in: query
+          description: The two-character state code of the address.
+          required: true
+          schema:
+            maxLength: 2
+            minLength: 2
+            pattern: ^(AA|AE|AL|AK|AP|AS|AZ|AR|CA|CO|CT|DE|DC|FM|FL|GA|GU|HI|ID|IL|IN|IA|KS|KY|LA|ME|MH|MD|MA|MI|MN|MS|MO|MP|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PW|PA|PR|RI|SC|SD|TN|TX|UT|VT|VI|VA|WA|WV|WI|WY)$
+            type: string
+        - name: urbanization
+          in: query
+          description: This is the urbanization code relevant only for Puerto Rico addresses.
+          required: false
+          schema:
+            type: string
+        - name: ZIPCode
+          in: query
+          description: This is the 5-digit ZIP code.
+          required: false
+          schema:
+            pattern: "^\\d{5}$"
+            type: string
+        - name: ZIPPlus4
+          in: query
+          description: This is the 4-digit component of the ZIP+4 code. Using the correct ZIP+4 reduces the number of times your mail is handled and can decrease the chance of a misdelivery or error.
+          required: false
+          schema:
+            pattern: "^\\d{4}$"
+            type: string
+      responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddressResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/AddressResponse'
+        "400":
+          description: Bad Request. There is an error in the received request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+              examples:
+                Invalid State Code:
+                  $ref: '#/components/examples/Invalid-State-Code'
+                Invalid City:
+                  $ref: '#/components/examples/Invalid-City'
+                Unverifiable City and State:
+                  $ref: '#/components/examples/Unverifiable-City-and-State'
+                Insufficient Address Data:
+                  $ref: '#/components/examples/Insufficient-Adddress-Data'
+                Invalid Delivery Address:
+                  $ref: '#/components/examples/Invalid-Delivery-Address'
+                Multiple Addresses Found:
+                  $ref: '#/components/examples/Multiple-Addresses-Found'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "401":
+          description: Unauthorized request.
+          headers:
+            WWW-Authenticate:
+              $ref: '#/components/headers/WWWAuthenticate'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "403":
+          description: Access is denied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "404":
+          description: Address Not Found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+              examples:
+                Address Not Found:
+                  $ref: '#/components/examples/Address-Not-Found'
+                No Match:
+                  $ref: '#/components/examples/No-Match'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "429":
+          description: Too Many Requests. Too many requests have been received from the client in a short amount of time.
+          headers:
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "503":
+          description: Service is unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        default:
+          description: Other unanticipated errors that may occur.
+          content: {}
+      security:
+        - OAuth:
+            - addresses
+  /city-state:
+    get:
+      tags:
+        - Resources
+      summary: Returns the city and state for a given ZIP Code.
+      description: Returns the city and state corresponding to the given ZIP Code&#8482;.
+      operationId: get-city-state
+      parameters:
+        - name: ZIPCode
+          in: query
+          description: This is the 5-digit ZIP code.
+          required: true
+          schema:
+            pattern: "^\\d{5}$"
+            type: string
+      responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CityStateResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/CityStateResponse'
+        "400":
+          description: A bad request was received.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "401":
+          description: Unauthorized request.
+          headers:
+            WWW-Authenticate:
+              $ref: '#/components/headers/WWWAuthenticate'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "403":
+          description: Access is denied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "429":
+          description: Too Many Requests. Too many requests have been received from the client in a short amount of time.
+          headers:
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "503":
+          description: Service is unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        default:
+          description: Other unanticipated errors that may occur.
+          content: {}
+      security:
+        - OAuth:
+            - addresses
+  /zipcode:
+    get:
+      tags:
+        - Resources
+      summary: Returns the ZIP Code for a given address.
+      description: "Returns the ZIP Code&#8482; and ZIP + 4&#174; corresponding to the given address, city, and state (use USPS state abbreviations)."
+      operationId: get-ZIPCode
+      parameters:
+        - name: firm
+          in: query
+          description: "Firm/business corresponding to the address."
+          schema:
+            type: string
+            maxLength: 50
+            minLength: 0
+        - name: streetAddress
+          in: query
+          description: The number of a building along with the name of the road or street on which it is located.
+          required: true
+          schema:
+            type: string
+        - name: secondaryAddress
+          in: query
+          description: "The secondary unit designator, such as apartment(APT) or suite(STE) number, defining the exact location of the address within a building.  For more information please see [Postal Explorer](https://pe.usps.com/text/pub28/28c2_003.htm)."
+          required: false
+          schema:
+            type: string
+        - name: city
+          in: query
+          description: This is the city name of the address.
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          description: This is the two-character state code of the address.
+          required: true
+          schema:
+            maxLength: 2
+            minLength: 2
+            pattern: ^(AA|AE|AL|AK|AP|AS|AZ|AR|CA|CO|CT|DE|DC|FM|FL|GA|GU|HI|ID|IL|IN|IA|KS|KY|LA|ME|MH|MD|MA|MI|MN|MS|MO|MP|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PW|PA|PR|RI|SC|SD|TN|TX|UT|VT|VI|VA|WA|WV|WI|WY)$
+            type: string
+        - name: ZIPCode
+          in: query
+          description: This is the 5-digit ZIP code.
+          required: false
+          schema:
+            pattern: "^\\d{5}$"
+            type: string
+        - name: ZIPPlus4
+          in: query
+          description: This is the 4-digit component of the ZIP+4 code. Using the correct ZIP+4 reduces the number of times your mail is handled and can decrease the chance of a misdelivery or error.
+          required: false
+          schema:
+            pattern: "^\\d{4}$"
+            type: string
+      responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZIPCodeResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ZIPCodeResponse'
+        "400":
+          description: There is an error in the received request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "401":
+          description: Unauthorized request.
+          headers:
+            WWW-Authenticate:
+              $ref: '#/components/headers/WWWAuthenticate'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "403":
+          description: Access is denied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "429":
+          description: Too Many Requests. Too many requests have been received from the client in a short amount of time.
+          headers:
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        "503":
+          description: Service is unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        default:
+          description: Other unanticipated errors that may occur.
+          content: {}
+      security:
+        - OAuth:
+            - addresses
+components:
+  schemas:
+    AddressResponse:
+      title: Address Response
+      type: object
+      properties:
+        firm:
+          maxLength: 50
+          minLength: 0
+          type: string
+          description: This is the firm/business name at the address.
+        address:
+          $ref: '#/components/schemas/DomesticAddress'
+        additionalInfo:
+          $ref: '#/components/schemas/AddressAdditionalInfo'
+        corrections:
+          $ref: '#/components/schemas/AddressCorrections'
+        matches:
+          $ref: '#/components/schemas/AddressMatches'
+        warnings:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            type: string
+            xml:
+              name: warning
+      additionalProperties: false
+      description: "Standardizes street addresses including city and street abbreviations, and provides missing information such as ZIP Code&#8482; and ZIP + 4&#174;."
+      xml:
+        name: AddressValidateResponse
+        wrapped: true
+    CityAndState:
+      title: City And State
+      type: object
+      properties:
+        city:
+          maxLength: 28
+          minLength: 1
+          type: string
+          description: This is the city name of the address.
+          example: "Des Moines"
+        state:
+          maxLength: 2
+          minLength: 2
+          pattern: "\\w{2}"
+          type: string
+          description: This is two-character state code of the address.
+          example: IA
+        ZIPCode:
+          maxLength: 5
+          minLength: 5
+          type: string
+          description: This is the ZIP Code of the address.
+          example: "50314"
+    AddressCorrections:
+      title: Address Corrections
+      type: array
+      description: |
+        Codes that indicate how to improve the address input to get a better match.
+        
+        Code `32` will indicate "Default address: The address you entered was found but more information is needed (such as an apartment, suite, or box number." The recommended change would be to add additional information, such as an apartment, suite, or box number, to match to a specific address.
+        
+        Code `22` will indicate "Multiple addresses were found for the information you entered, and no default exists." The address could not be resolved as entered and more information would be needed to identify the address.
+      xml:
+        name: addressCorrections
+        wrapped: true
+      items:
+        type: object
+        properties:
+          code:
+            maxLength: 2
+            minLength: 1
+            pattern: "\\w{2}"
+            type: string
+            description: The code corresponding to the address correction.
+            xml:
+              name: code
+          text:
+            type: string
+            description: This is the description of the address correction.
+            xml:
+              name: text
+        additionalProperties: false
+        xml:
+          name: addressCorrection
+    AddressMatches:
+      title: Address Matches
+      type: array
+      description: |
+        Codes that indicate if an address is an exact match.
+        
+        Code `31` will be returned "Single Response - exact match" indicating that the address was correctly matched to a ZIP+4 record.
+      xml:
+        name: addressMatches
+        wrapped: true
+      items:
+        type: object
+        properties:
+          code:
+            maxLength: 2
+            minLength: 1
+            pattern: "\\w{2}"
+            type: string
+            xml:
+              name: code
+          text:
+            type: string
+            xml:
+              name: text
+        additionalProperties: false
+        xml:
+          name: addressMatch
+    AddressAdditionalInfo:
+      title: Address Additional Information
+      type: object
+      properties:
+        deliveryPoint:
+          type: string
+          description: |-
+            A specific set of digits between 00 and 99 is assigned to every address that is combined with the ZIP + 4&#174; Code to provide a unique identifier for every delivery address.
+
+            A street address does not necessarily represent a single delivery point because a street address such as one for an apartment building may have several delivery points.
+        carrierRoute:
+          maxLength: 5
+          minLength: 0
+          type: string
+          description: This is the carrier route code (values unspecified).
+          example: "C012"
+        DPVConfirmation:
+          type: string
+          description: |
+            The DPV Confirmation indicator identifies whether the address provided maps to a known USPS address record, whether the USPS delivers to the address or not. If the USPS does not deliver to the address, the USPS may deliver to a PO Box instead. `carrierRoute` values of `R777` and `R779`, for example, may require the shipper to ask the recipient where they receive their USPS mail, which may be different than their physical address.
+
+            * `Y` - Address was DPV confirmed for both primary and (if present) secondary numbers.  A value of `Y` does not necessarily imply that USPS delivers to that address.
+            * `D` - Address was DPV confirmed for the primary number only, and the secondary number information was missing.
+            * `S` - Address was DPV confirmed for the primary number only, and the secondary number information was present but not confirmed.
+            * `N` - Both primary and (if present) secondary number information failed to DPV confirm.
+          enum:
+            - "Y"
+            - D
+            - S
+            - "N"
+        DPVCMRA:
+          type: string
+          description: |-
+            Indicates if the location is a [Commercial Mail Receiving Agency (CMRA)](https://faq.usps.com/s/article/Commercial-Mail-Receiving-Agency-CMRA).
+             * `Y` - Address was found in the CMRA table.
+             * `N` - Address was not found in the CMRA table.
+          enum:
+            - "Y"
+            - "N"
+        business:
+          type: string
+          description: |
+            Indicates whether this is a business address.
+            * `Y` - The address is a business address.
+            * `N` - The address is not a business address.
+          enum:
+            - "Y"
+            - "N"
+        centralDeliveryPoint:
+          type: string
+          description: |
+            Central Delivery is for all business office buildings and/or industrial/professional parks. This may include call windows, horizontal locked mail receptacles, and cluster box units.
+            * `Y` - The address is a central delivery point.
+            * `N` - The address is not a central delivery point.
+          enum:
+            - "Y"
+            - "N"
+        vacant:
+          type: string
+          description: |
+            Indicates whether the location designated by the address is occupied.
+            * `Y` - The address is not occupied.
+            * `N` - The address is occupied.
+          enum:
+            - "Y"
+            - "N"
+      additionalProperties: false
+      description: Extra information about the request.
+      xml:
+        name: addressAdditionalInfo
+    CityStateResponse:
+      title: City and State Response
+      description: The validated ZIP Code&#8482; for a given city and state.
+      xml:
+        name: CityStateLookupResponse
+        wrapped: true
+      allOf:
+        - $ref: '#/components/schemas/CityAndState'
+    ZIPCodeResponse:
+      title: ZIP Code&#8482; Response
+      type: object
+      properties:
+        firm:
+          maxLength: 50
+          minLength: 0
+          type: string
+          description: This is the firm/business name at the address.
+        address:
+          $ref: '#/components/schemas/DomesticAddress'
+      additionalProperties: false
+      description: The address to validate the ZIP Code&#8482; for.
+      xml:
+        name: ZipCodeLookupResponse
+        wrapped: true
+    ErrorMessage:
+      title: Error
+      type: object
+      properties:
+        apiVersion:
+          type: string
+          description: The version of the API that was used and that raised the error.
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: The error status code that has been returned in response to the request.
+            message:
+              type: string
+              description: A human-readable message describing the error.
+            errors:
+              type: array
+              items:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    description: The status code response returned to the client.
+                  code:
+                    type: string
+                    description: An internal subordinate code used for error diagnosis.
+                  title:
+                    type: string
+                    description: A human-readable title that identifies the error.
+                  detail:
+                    type: string
+                    description: A human-readable description of the error that occurred.
+                  source:
+                    type: object
+                    properties:
+                      parameter:
+                        type: string
+                        description: The input in the request which caused an error.
+                      example:
+                        type: string
+                        description: An example of a valid value for the input parameter.
+                    additionalProperties: true
+                    description: The element that is suspected of originating the error.  Helps to pinpoint the problem.
+                additionalProperties: true
+          additionalProperties: true
+          description: The high-level error that has occurred as indicated by the status code.
+      additionalProperties: true
+      description: Standard error message response.
+    DomesticAddress:
+      title: Domestic Address
+      additionalProperties: true
+      description: Address fields for US locations
+      allOf:
+        - $ref: '#/components/schemas/Address'
+        - type: object
+          properties:
+            city:
+              maxLength: 28
+              minLength: 1
+              type: string
+              description: This is the city name of the address.
+            state:
+              $ref: '#/components/schemas/State'
+            ZIPCode:
+              pattern: "\\d{5}"
+              type: string
+              description: This is the 5-digit ZIP code.
+            ZIPPlus4:
+              pattern: "\\d{4}"
+              type: string
+              description: This is the 4-digit component of the ZIP+4 code. Using the correct ZIP+4 reduces the number of times your mail is handled and can decrease the chance of a misdelivery or error.
+              nullable: true
+            urbanization:
+              maxLength: 96
+              type: string
+              description: "An area, sector, or residential development within a geographic area (typically used for addresses in Puerto Rico)."
+          additionalProperties: true
+    Address:
+      title: Address
+      type: object
+      properties:
+        streetAddress:
+          maxLength: 50
+          minLength: 1
+          type: string
+          description: The number of a building along with the name of the road or street on which it is located.
+        streetAddressAbbreviation:
+          maxLength: 50
+          minLength: 0
+          type: string
+          description: This is the abbreviation of the primary street address line for the address.
+          readOnly: true
+        secondaryAddress:
+          maxLength: 50
+          type: string
+          description: "The secondary unit designator, such as apartment(APT) or suite(STE) number, defining the exact location of the address within a building.  For more information please see [Postal Explorer](https://pe.usps.com/text/pub28/28c2_003.htm)."
+        cityAbbreviation:
+          type: string
+          description: This is the abbreviation of the city name for the address.
+          readOnly: true
+      additionalProperties: true
+      description: Address fields standard to all locations.
+      xml:
+        name: Address
+    State:
+      maxLength: 2
+      minLength: 2
+      pattern: ^(AA|AE|AL|AK|AP|AS|AZ|AR|CA|CO|CT|DE|DC|FM|FL|GA|GU|HI|ID|IL|IN|IA|KS|KY|LA|ME|MH|MD|MA|MI|MN|MS|MO|MP|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PW|PA|PR|RI|SC|SD|TN|TX|UT|VT|VI|VA|WA|WV|WI|WY)$
+      type: string
+      description: The two-character state code.
+  parameters:
+    StreetAddress-Required:
+      name: streetAddress
+      in: query
+      description: The number of a building along with the name of the road or street on which it is located.
+      required: true
+      schema:
+        type: string
+    SecondaryAddress:
+      name: secondaryAddress
+      in: query
+      description: "The secondary unit designator, such as apartment(APT) or suite(STE) number, defining the exact location of the address within a building.  For more information please see [Postal Explorer](https://pe.usps.com/text/pub28/28c2_003.htm)."
+      required: false
+      schema:
+        type: string
+    City:
+      name: city
+      in: query
+      description: This is the city name of the address.
+      required: false
+      schema:
+        type: string
+    State-Required:
+      name: state
+      in: query
+      description: This is two-character state code of the address.
+      required: true
+      schema:
+        maxLength: 2
+        minLength: 2
+        pattern: ^(AA|AE|AL|AK|AP|AS|AZ|AR|CA|CO|CT|DE|DC|FM|FL|GA|GU|HI|ID|IL|IN|IA|KS|KY|LA|ME|MH|MD|MA|MI|MN|MS|MO|MP|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PW|PA|PR|RI|SC|SD|TN|TX|UT|VT|VI|VA|WA|WV|WI|WY)$
+        type: string
+    Urbanization:
+      name: urbanization
+      in: query
+      description: This is the urbanization code relevant only for Puerto Rico addresses.
+      required: false
+      schema:
+        type: string
+    ZIPCode:
+      name: ZIPCode
+      in: query
+      description: This is the 5-digit ZIP code.
+      required: false
+      schema:
+        pattern: "^\\d{5}$"
+        type: string
+    ZIPPlus4:
+      name: ZIPPlus4
+      in: query
+      description: This is the 4-digit component of the ZIP+4 code. Using the correct ZIP+4 reduces the number of times your mail is handled and can decrease the chance of a misdelivery or error.
+      required: false
+      schema:
+        pattern: "^\\d{4}$"
+        type: string
+    ZIPCode-Required:
+      name: ZIPCode
+      in: query
+      description: This is the 5-digit ZIP code.
+      required: true
+      schema:
+        pattern: "^\\d{5}$"
+        type: string
+    City-Required:
+      name: city
+      in: query
+      description: This is the city name of the address.
+      required: true
+      schema:
+        type: string
+  examples:
+    Invalid-City:
+      summary: The city is missing or invalid.
+      description: The city is missing or invalid.
+      value:
+        apiVersion: v1
+        error:
+          code: "400"
+          message: The city in the request is missing or invalid.
+          errors: []
+    Invalid-State-Code:
+      summary: The two-letter state code is missing or invalid.
+      description: The two-letter state code is missing or invalid.
+      value:
+        apiVersion: v1
+        error:
+          code: "400"
+          message: The state code in the request is missing or invalid.
+          errors: []
+    Unverifiable-City-and-State:
+      summary: The city and state are missing or together unverifiable.
+      description: The city and state are missing or together unverifiable.
+      value:
+        apiVersion: v1
+        error:
+          code: "400"
+          message: The city and state are missing or together unverifiable.
+          errors: []
+    Insufficient-Adddress-Data:
+      summary: The address information in the request is insufficient to match.
+      description: The address information in the request is insufficient to match.
+      value:
+        apiVersion: v1
+        error:
+          code: "404"
+          message: The address information in the request is insufficient to match.
+          errors: []
+    Address-Not-Found:
+      summary: The address requested could not be found.
+      description: "There is no match for the specified address, try adding as much information as possible."
+      value:
+        apiVersion: v1
+        error:
+          code: "404"
+          message: There is no match for the address requested.
+          errors: []
+    No-Match:
+      summary: Could not find any matching address.
+      description: "There is no match for the specified address, try adding as much information as possible."
+      value:
+        apiVersion: v1
+        error:
+          code: "404"
+          message: There is no match for the address requested.
+          errors: []
+    Invalid-Delivery-Address:
+      summary: The address requested is an invalid delivery address.
+      description: The address requested is an invalid delivery address.
+      value:
+        apiVersion: v1
+        error:
+          code: "404"
+          message: The address requested is an invalid delivery address.
+          errors: []
+    Multiple-Addresses-Found:
+      summary: More than one address was found matching the requested address.
+      description: More than one address was found matching the requested address.
+      value:
+        apiVersion: v1
+        error:
+          code: "404"
+          message: More than one address was found matching the requested address.
+          errors: []
+  headers:
+    WWWAuthenticate:
+      description: Hint to the client application which security scheme to authorize a resource request.
+      required: false
+      schema:
+        type: string
+        example: "WWW-Authenticate: Bearer realm=\"https://api.usps.com\""
+    RetryAfter:
+      description: Indicate to the client application a time after which they can retry a resource request.
+      required: false
+      schema:
+        type: string
+        example: "Retry-After: 30"
+  securitySchemes:
+    OAuth:
+      type: oauth2
+      description: The specified APIs accept an access token formatted as a JSON Web Token. The relative path to the OAuth2 version 3 API which supplies this access token is provided below for reference.
+      flows:
+        clientCredentials:
+          tokenUrl: /oauth2/v3/token
+          scopes:
+            addresses: read-only access to all addresses endpoints
+        authorizationCode:
+          authorizationUrl: /oauth2/v3/authorize
+          tokenUrl: /oauth2/v3/token
+          scopes:
+            addresses: read-only access to all addresses endpoints

--- a/docs/usps/oauth2_update.yaml
+++ b/docs/usps/oauth2_update.yaml
@@ -1,0 +1,819 @@
+openapi: 3.0.1
+info:
+  title: Open Authorization (OAuth 2.0) 3.0
+  description: |
+  
+    Contact Us: [USPS API Support](https://emailus.usps.com/s/usps-APIs) | [Terms of Service](https://about.usps.com/termsofuse.htm)
+  
+    OAuth access tokens are used to grant authorized access to USPS&#174; APIs.
+    Access tokens will expire, requiring applications to periodically check the expiration time and get new tokens.
+    
+    
+    The following __OAuth 2.0__ grant types are supported:
+    
+    
+
+    * _**Client Credentials**_: The token request exchanges the client Id and secret to get an access token. The client Id and secret are the credentials for your client application and are validated.
+
+
+    * _**Refresh Token**_: The refresh token is exchanged to get a new access token and an optional refresh token. The refresh token is validated and must not have expired or been revoked.
+
+    * _**Authorization Code**_: The token request exchanges an authorization code previously received for access and refresh tokens. User (Resource Owner) authentication and consent is prerequisite for authorization code generation. The authorization code is validated and must not have expired.
+    
+    Other OAuth flows may become supported in future releases.
+    
+    
+    You will need to add an app to get a client Id and secret. These are the _**Consumer Key**_ and _**Consumer Secret**_ values in the API developer portal.
+    
+    
+    
+    
+    Each API will stipulate the level of authentication assurance required to access its resources, either *Client Application* or *Resource Owner* credentials.  The access token value is placed in the *Authorization* header in accordance with the *Bearer* token authentication scheme.
+
+     ```
+     Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJ1c3BzLmNvbSIsInN1YiI6IjI0ODI4OTc2MTAwMSIsImF1ZCI6InM2QmhkUmtxdDMiLCJub25jZSI6Im4tMFM2X1d6QTJNaiIsImV4cCI6MTMxMTI4MTk3MCwiaWF0IjoxMzExMjgwOTcwLCJuYW1lIjoiSmFuZSBEb2UiLCJnaXZlbl9uYW1lIjoiSmFuZSIsImZhbWlseV9uYW1lIjoiRG9lIiwibG9jYWxlIjoiZW4tdXMiLCJhenAiOiJ1c3BzLmNvbSIsImFjciI6IkFBTDEiLCJhbXIiOiJwd2QifQ.qJ2SUGKn4TabFfMYODW1RLxirFmeeYPDyFvuJR0ywRVaRnoe7Rlk8yKM3v2fCBUi2lMo00whNhNWmqQktpGgvkVGWXGMNIlVxJCqt_aPFx3oOvkhKWGI49JI5NyXrpj4tfYD5pIYbrihkF7eMYG3XyqYMx1VLhhV0PmWhpq787K7_AGfRlNVQnD_WEHJt4SoEnsiw8vcwDWXcXr5yCzAEn8mfCSTlamqVBUyey1Fyg_xgQIRj_b9CO-O4kXsBM3vqo5CO2qET2tRd37niaQvV-g418sEpnw1iAtxWfcyU4IIjWlQa7AxAc3T4Vx6XOwn1CNI22ZhdaBskUtD-EexWQ
+
+     ```
+    
+    Each API will validate the access token, its expiration in addition to its OAuth scope for example. There may be further validations required which are specific to the resource being accessed.
+    
+    
+    You will need to get a new access token once the one you have has expired. It is best practice to get a new access token before expiration if further access to resources is needed.
+    
+    You may also revoke a refresh token which you suspect has been disclosed or dispose it when it is no longer needed.
+      
+    
+
+#  Resource Owner Password Credentials Flow omitted.    
+
+  version: 3.1.4
+
+#  OpenAPI Specification, versions 3.0.0, 3.0.1, 3.1.1 and 3.2 do not support a URL as an email address in Contact Object.
+
+  
+servers:
+  - url: https://apis.usps.com/oauth2/v3
+    description: Production Environment Endpoint
+
+  - url: https://apis-tem.usps.com/oauth2/v3
+    description: Testing Environment Endpoint
+  
+# ReDoc limitation does not use Server Variable Objects in the DX UI.
+
+
+tags:
+ - name:  Resources
+   description: Defined by the IETF OAuth industry standards, see [The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749).  See also [Best Current Practice for OAuth 2.0 Security](https://datatracker.ietf.org/doc/html/rfc9700) for security awareness.
+   
+paths:
+
+  /token:
+    summary: Generate OAuth tokens.
+    description: |
+      Issue access and refresh tokens. Based on the \'OAuth 2.0 Authorization Framework\', IETF Draft RFC 6749, October 2012, see [The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749).
+      
+      The _expires_in_ and _refresh_token_expires_in_ fields in the token response specify the respective valid lifetimes for each token.
+
+    post:
+      summary: Generate OAuth tokens.
+      description: |
+        Issue one or more OAuth tokens for a client application to use to make subsequent resource requests.
+        Based on the _OAuth 2.0 Authorization Framework_, IETF Draft RFC 6749, October 2012, see [The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749).
+        
+        The _expires_in_ and _refresh_token_expires_in_ fields in the token response specify the respective valid lifetimes for each token.
+
+
+        The following OAuth grant types are supported:
+        
+        - **Client Credentials Grant**, see [IETF 6749, section 4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
+
+        - **Refresh Token**, see [IETF 6749, section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6)
+                
+        - **Authorization Code Grant**, see [IETF 6749, section 4.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1).
+        
+        
+        
+#        Resource Owner Password Credentials Flow omitted.
+
+      tags:
+        - Resources
+      operationId: post-token
+      requestBody:
+        description: |
+          The input parameters corresponding to the supported grant types.
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/ClientCredentials'
+              - $ref: '#/components/schemas/RefreshTokenCredentials'
+              - $ref: '#/components/schemas/AuthorizationCodeCredentials'
+              discriminator:
+                propertyName: grant_type
+                mapping:
+                  client_credentials: '#/components/schemas/ClientCredentials'
+                  refresh_token: '#/components/schemas/RefreshTokenCredentials'
+                  authorization_code: '#/components/schemas/AuthorizationCodeCredentials'
+#                 Resource Owner Password Credentials omitted.
+            examples:
+              client-credentials-grant:
+                $ref: '#/components/examples/clientCredentialsTokenRequest'
+              refresh-token-credentials-grant:
+                $ref: '#/components/examples/refreshTokenCredentialsTokenRequest'
+              authorization-code-grant:
+                $ref: '#/components/examples/authorizationCodeTokenRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/ClientCredentials'
+              - $ref: '#/components/schemas/RefreshTokenCredentials'
+              - $ref: '#/components/schemas/AuthorizationCodeCredentials'
+              discriminator:
+                propertyName: grant_type
+                mapping:
+                  client_credentials: '#/components/schemas/ClientCredentials'
+                  refresh_token: '#/components/schemas/RefreshTokenCredentials'
+                  authorization_code: '#/components/schemas/AuthorizationCodeCredentials'
+#                 Resource Owner Password Credentials omitted.
+      responses:
+        "200":
+          description: Token Issued.
+            Client application authorization has been granted and OAuth token(s) issued.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/ClientApplicationTokenResponse'
+                - $ref: '#/components/schemas/ResourceOwnerTokenResponse'
+              examples:
+                client-credentials-grant:
+                  $ref: '#/components/examples/clientCredentialsTokenResponse'
+                refresh-token-grant:
+                  $ref: '#/components/examples/refreshTokenResponse'
+                authorization-code-grant:
+                  $ref: '#/components/examples/authorizationCodeTokenResponse'
+#                 Resource Owner Password Credentials omitted.
+        "400":
+          description: Bad Request.  Check the input parameters and values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardErrorResponse'
+              examples:
+                invalid_refresh-token-response:
+                  $ref: '#/components/examples/invalidRefreshTokenResponse'
+                expired-refresh-token-response:
+                  $ref: '#/components/examples/invalidRefreshTokenExpiredResponse'
+                invalid-authorization-code-response:
+                  $ref: '#/components/examples/invalidAuthorizationCodeResponse'
+        "401":
+          description: Unauthorized Request.  Check the authentication scheme and values being used to make the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardErrorResponse'
+              examples:
+                invalid-client-identifier:
+                  $ref: '#/components/examples/invalidClientIdentifierResponse'
+                invalid-client-credentials:
+                  $ref: '#/components/examples/invalidClientCredentialsResponse'
+          headers:
+            WWW-Authenticate:
+              $ref: '#/components/headers/WWWAuthenticate'
+        "429":
+          description: Too Many Requests. Too many requests have been received from client in a short amount of time.
+          headers:
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardErrorResponse'
+              examples:
+                spike-arrest-violation:
+                  $ref: '#/components/examples/spikeArrestViolationResponse'
+        "503":
+          description: Service Unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardErrorResponse'
+          headers:
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'
+          
+
+  /revoke:
+    summary: Invalidate OAuth tokens.
+    description: |
+      Prevent tokens from being further used to access APIs by invalidating OAuth tokens which are no longer needed. This resource is based on the \'OAuth 2.0 Token Revocation\', IETF Draft RFC 7009, August 2013, see [OAuth 2.0 Token Revocation](https://datatracker.ietf.org/doc/html/rfc7009).
+      
+      
+      Basic Authentication is used to access this resource, using the issued client Id and client secret.
+      
+      Only refresh tokens may be revoked, since access tokens are self-contained, and formatted using JSON Web Token industry standard.
+      
+    post:
+      summary: 'Invalidate OAuth tokens.'
+      description: |
+        Prevent tokens from being further used to access APIs by invalidating OAuth tokens which are no longer needed. This resource is based on the \'OAuth 2.0 Token Revocation\', IETF Draft RFC 7009, August 2013, see [OAuth 2.0 Token Revocation](https://datatracker.ietf.org/doc/html/rfc7009).
+        
+       
+        Basic Authentication is used to access this resource, using the issued client Id and client secret.
+           
+        ```
+        Authorization: Basic N0MyejJiS1FodDJUTEJjVTE2VmxlZUplQm1hdExiMjQ6TENtSE85RUFENXk0bUNURA==
+        ```
+        
+        
+        Only refresh tokens may be revoked, since access tokens are self-contained, and formatted using JSON Web Token industry standard.
+       
+      tags:
+        - Resources
+      operationId: post-revoke
+      requestBody:
+        description: |
+          The token to be inspected. The hint is used to locate the token.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenRevokeRequest'
+            examples:
+              revoke-request-example:
+                $ref: '#/components/examples/revokeTokenRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenRevokeRequest'
+      security:
+        - BasicAuth: [ ]
+        
+      responses:
+        "200":
+          description: Successful Operation. No response payload.
+        "400":
+          description: Bad Request.  Check the input parameters and values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardErrorResponse'
+              examples:
+                expired-refresh-token-response:
+                  $ref: '#/components/examples/invalidRefreshTokenExpiredResponse'
+        "401":
+          description: Unauthorized Request.  Check the authentication scheme and values being used to make the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardErrorResponse'
+              examples:
+                invalid-client-identifier:
+                  $ref: '#/components/examples/invalidClientIdentifierResponse'
+                invalid-client-credentials:
+                  $ref: '#/components/examples/invalidClientCredentialsResponse'
+          headers:
+            WWW-Authenticate:
+              $ref: '#/components/headers/WWWAuthenticate'
+        "429":
+          description: Too Many Requests. Too many requests have been received from client in a short amount of time.
+          headers:
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardErrorResponse'
+              examples:
+                spike-arrest-violation:
+                  $ref: '#/components/examples/spikeArrestViolationResponse'
+        "503":
+          description: Service Unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardErrorResponse'
+          headers:
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'              
+
+components:
+
+  headers:
+  
+    RetryAfter:
+      description: Indicate to the client application a time after which they can retry a resource request.
+      schema:
+        type: string
+        example: 'Retry-After: 30'
+      
+    WWWAuthenticate:
+       description: Hint to the client application which security scheme to authorize a resource request.
+       schema:
+         type: string
+         example: 'WWW-Authenticate: Bearer realm="https://api.usps.com/realms/USPS"'
+       
+  securitySchemes:
+  
+    BasicAuth:
+      description: Use the client_id and client_secret for the username and password, respectfully. The client application is authenticated using the Basic authentication security scheme.
+      type: http
+      scheme: basic
+      
+    BearerTokenAuth:
+      description: An access token is used to authenticate the client application making the request.
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      
+  schemas:
+  
+    TokenRequest:
+      title:  Token Request
+      description: The base object for an OAuth token request, in accordance with OAuth industry standards.
+      type: object
+      required:
+        - grant_type
+      oneOf:
+      - $ref: '#/components/schemas/AuthorizationCodeCredentials'
+      - $ref: '#/components/schemas/ClientCredentials'
+      - $ref: '#/components/schemas/RefreshTokenCredentials'
+#           Resource Owner Password Credentials Flow omitted.
+      properties:
+        grant_type:
+          description: The OAuth standard flow being requested by the client application.
+          type: string
+          enum:
+            - client_credentials
+            - refresh_token
+            - authorization_code
+#           Resource Owner Password Credentials Flow omitted.
+        scope:
+          description: |
+            The OAuth2 scope being requested. A client application may request a subset of scope that has already been configured during registration.
+            
+            The default scope registered for the client application is used as default when the scope is omitted.
+            
+            **Only specify the scope in the request when the client application requires less scope, i.e. less access to APIs, than the default.**
+          type: string
+          default: ""
+      additionalProperties: true
+          
+
+          
+    ClientCredentials:
+      title: Client Credentials Token Request
+      description: The client credentials are used to get an access token. The credentials of the client application that are verified by the authorization server.
+        The value of the grant_type is 'client_credentials'
+      required:
+        - client_id
+        - client_secret      
+      allOf:
+        - $ref: '#/components/schemas/TokenRequest'
+        - type: object
+          properties:
+             client_id:
+               description: |
+                 The unique identifier issued to the client application making the request. Used for authenticating the client application.
+                 
+                 You will need to add an app to get a client Id and secret. These are the Consumer Key and Consumer Secret values respectfully in the API developer portal.
+               type: string
+             client_secret:
+               description: |
+                  The shared secret issued to the client application making the request. Used for authenticating the client application.
+
+                  You will need to add an app to get a client Id and secret. These are the Consumer Key and Consumer Secret values respectfully in the API developer portal.
+               type: string
+          additionalProperties: false
+      additionalProperties: false
+          
+    AuthorizationCodeCredentials:
+      title: Authorization Code Credentials Token Request
+      description: The client credentials in addition to the authorization code received earlier are used to get access and refresh tokens. The credentials of the client application that are verified by the authorization server.
+        The value of the grant_type is 'authorization_code'.
+      required:
+        - code
+        - redirect_uri
+      allOf:
+        - $ref: '#/components/schemas/ClientCredentials'
+        - type: object
+          properties:
+             redirect_uri:
+               description: |
+                 The authorization code redirect Uniform Resource Identifier (URI) for the third-party application to receive the authorization code. This is used to verify the identify of the requester. The request will not be redirected to this URI.
+               type: string
+             code:
+               description:  The authorization code previously received by the client application.
+               type: string
+          additionalProperties: false
+      additionalProperties: false
+          
+    RefreshTokenCredentials:
+      title: Refresh Token Credentials Request
+      description: The client credentials in addition to the refresh token received earlier are used to get access and refresh tokens. The credentials of the client application that are verified by the authorization server.
+        The value of the grant_type is 'refresh_token'.
+      required:
+        - refresh_token
+      allOf:
+        - $ref: '#/components/schemas/ClientCredentials'
+        - type: object
+          properties:
+            refresh_token:
+              description:  The refresh token value to be used to issue a new access token.
+              type: string
+          additionalProperties: false
+      additionalProperties: false
+         
+#   Resource Owner Password Credentials omitted.
+
+    TokenRevokeRequest:
+      title: Token Revocation Request
+      description: The token revocation request.
+      type: object
+      required:
+        - token      
+      properties:
+        token:
+          description: The token (a hash value).
+          type: string
+        token_type_hint:
+          description: A hint to the type of the given token. See OAuth Token Types Hint registry, https://www.rfc-editor.org/rfc/rfc7009#section-4.1.2.1
+          type: string
+          enum:
+            - 'access_token'
+            - 'refresh_token'
+          default:
+            'refresh_token'
+      additionalProperties: false
+      
+    ClientApplicationTokenResponse:
+      title: Client Application Token Response
+      description: |
+        The OAuth token response for third-party client applications to use to access USPS APIs.
+        The access token is returned in the response. You may use [The Unix Epoch Time Converter](https://www.epochconverter.com/) to convert access token issued at values to human readable formats.
+        Use the public key provided in the response to verify the access token signature.
+
+      readOnly: true
+      required:
+        - access_token
+        - expires_in
+        - token_type      
+      properties:
+        access_token:
+          description: The access token issued to use to acess protected resources.
+          type: string
+        issued_at:
+          description: |
+            The date and time the access token was issued, expressed in Unix epoch time in milliseconds.
+            You may use [The Unix Epoch Time Converter](https://www.epochconverter.com/) to convert access token issued at values to human readable formats.
+          type: integer
+          format: int64
+        expires_in:
+          description: The expiration time of the issued access token, in seconds.
+          type: integer
+          example: 28799
+        token_type:
+          description: The access token type provides the client with the information required to successfully utilize the access token to make a protected resource request (along with type-specific attributes).  The client MUST NOT use an access token if it does not understand the token type.
+          type: string
+          enum:
+            - Bearer
+          default: 'Bearer'
+        status:
+          description: The status of the access token.
+          type: string
+          enum:
+            - approved
+            - revoked
+        issuer:
+          description:  The authority that issued the token(s).
+          type: string
+          format: Uri
+          example: 'https://api.usps.com/realms/USPS'
+        scope:
+          description: The OAuth scope being requested by the client application, specified as a list of space-delimited, case-sensitive strings.  If ommitted from the token request then the default scope configured for the client application is used.
+          type: string
+        client_id:
+          description:  The unique identifier for the client application.
+          type: string
+        application_name:
+          description: The name of the client application.
+          type: string
+        api_products:
+          description: The list of API products approved for use by the client application.
+          type: string
+        public_key:
+          description: The base64-encoded public cryptographic key used to validate the signature of the access token.  Validation ensures that the access token has not been tampered with and it originated from a known, trusted source.
+          type: string
+          format: byte
+      additionalProperties: false
+      
+    ResourceOwnerTokenResponse:
+      title: Resource Owner Token Response
+      description: |
+        The OAuth token response for third-party client applications to use to access USPS APIs on behalf of USPS customers.
+        Both access and refresh tokens are returned in the response. You may use [The Unix Epoch Time Converter](https://www.epochconverter.com/) to convert access token issued at values to human readable formats.
+        Use the public key provided in the response to verify the access token signature.
+        
+      readOnly: true
+      required:
+        - access_token
+        - expires_in
+        - token_type    
+        - refresh_token
+        - refresh_token_expires_in
+      properties:
+        access_token:
+          description: The access token issued to use to acess protected resources.
+          type: string
+        issued_at:
+          description: |
+            The date and time the access token was issued, expressed in Unix epoch time in milliseconds.
+            You may use [The Unix Epoch Time Converter](https://www.epochconverter.com/) to convert access token issued at values to human readable formats.
+          type: integer
+          format: int64
+        expires_in:
+          description: The expiration time of the issued access token, in seconds.
+          type: integer
+          example: 28799
+        token_type:
+          description: The access token type provides the client with the information required to successfully utilize the access token to make a protected resource request (along with type-specific attributes).  The client MUST NOT use an access token if it does not understand the token type.
+          type: string
+          enum:
+            - Bearer
+          default: 'Bearer'
+        status:
+          description: The status of the access token.
+          type: string
+          enum:
+            - approved
+            - revoked
+        issuer:
+          description:  The authority that issued the token(s).
+          type: string
+          example: 'https://api.usps.com/realms/USPS'
+        scope:
+          description: The OAuth scope being requested by the client application, specified as a list of space-delimited, case-sensitive strings.  If ommitted from the token request then the default scope configured for the client application is used.
+          type: string
+        refresh_token:
+          description: The refresh token.
+          type: string
+        refresh_token_issued_at:
+          description: |
+            The date and time the refresh token was issued expressed in Unix epoch time in milliseconds.
+            You may use [The Unix Epoch Time Converter](https://www.epochconverter.com/) to convert refresh token issued at values to human readable formats.
+          type: integer
+          format: int64
+        refresh_token_expires_in:
+          description: The refresh token expiration, in seconds.
+          type: integer
+          example: 604799
+        refresh_count:
+          description: The number of times the refresh token operation has been used.
+          type: integer
+        refresh_token_status:
+          description: The current state of the refresh token.
+          type: string
+          enum:
+            - approved
+            - revoked
+        client_id:
+          description:  The unique identifier for the client application.
+          type: string
+        application_name:
+          description: The name of the client application.
+          type: string
+        api_products:
+          description: The list of API products approved for use by the client application.
+          type: string
+        public_key:
+          description: The base64-encoded public cryptographic key used to validate the signature of the access token.  Validation ensures that the access token has not been tampered with and it originated from a known, trusted source.
+          type: string
+          format: byte
+      additionalProperties: false
+      
+    StandardErrorResponse:
+      title: OAuth Standard Error Response
+      description: The authorization server responds with an HTTP 400 (Bad Request) status code (unless specified otherwise) and includes the following parameters with the response.
+      readOnly: true
+      type: object
+      properties:
+        error:
+          description: See [The OAuth 2.0 Authorization Framework, Section 5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2), for information about the specific error codes.
+          type: string
+          enum:
+            - invalid_request
+            - invalid_client
+            - invalid_grant
+            - unauthorized_client
+            - unsupported_grant_type
+            - invalid_scope
+        error_description:
+          description: A human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.
+          type: string
+        error_uri:
+          description: A URI identifying a human-readable web page with information about the error, used to provide the client developer with additional information about the error.
+          type: string
+      additionalProperties: true
+      
+  examples:
+      
+     clientCredentialsTokenRequest:
+      summary: Client credentials token request example.
+      value:
+        {
+          "grant_type": "client_credentials",
+          "client_id": "123456789",
+          "client_secret": "A1B2c3d4E5"
+        }
+
+     authorizationCodeTokenRequest:
+      summary: Authorization code token request example.
+      value:
+        {
+          "grant_type": "authorization_code",
+          "client_id": "123456789",
+          "client_secret": "A1B2c3d4E5",
+          "redirect_uri": "https://mycompany.com/authorize",
+          "code": "EyQPFYVI"
+        }
+        
+     refreshTokenCredentialsTokenRequest:
+      summary: Refresh Token credentials token request example.
+      value:
+        {
+          "grant_type": "refresh_token",
+          "client_id": "123456789",
+          "client_secret": "A1B2c3d4E5",
+          "refresh_token": "ExDTmpomcDt6pTbFVvSgQ1km39YmX8Oy"
+        }
+        
+#  Resource Owner Password Credentials omitted.
+
+     revokeTokenRequest:
+       summary: Token revocation request JSON example.
+       value:
+         {
+         "token":"ExDTmpomcDt6pTbFVvSgQ1km39YmX8Oy",
+         "token_type_hint":"refresh_token"
+         }
+
+#  Authorization code Flow (POST) omitted.
+         
+     clientCredentialsTokenResponse:
+       summary: An access token is returned. The access token is self-contained and in JSON Web Token format.
+       description: The public key provided should be used to verify the access token signature.
+       value:
+          {
+              "access_token": "eyJraWQiOiIxMDEwMTAiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIiLCJhdWQiOiJhZGRyZXNzZXMgaW50ZXJuYXRpb25hbC1wcmljZXMgc3Vic2NyaXB0aW9ucyBwYXltZW50cyBwaWNrdXAgdHJhY2tpbmcgbGFiZWxzIHNjYW4tZm9ybXMgY29tcGFuaWVzIHNlcnZpY2UtZGVsaXZlcnktc3RhbmRhcmRzIGxvY2F0aW9ucyBpbnRlcm5hdGlvbmFsLWxhYmVscyBwcmljZXMiLCJhenAiOiJoeXI3YjN2Q1J0cFl0QUhNMWE4Y2RVcmt5eUZtTmtiZyIsIm9yZ2FuaXphdGlvbl9pZCI6IjAiLCJpc3MiOiJ1cm46XC9cL2FwaS51c3BzLmNvbSIsImV4cCI6MTY4MDkxNzc4NiwiaWF0IjoxNjgwODg4OTg2LCJqdGkiOiI3YjU5MzJlMS05NjIxLTQzZDAtYTMyNy0xMzIxYWVjNzJjZGYifQ.QzrUxlT2rG4jvYbMDGnk23j8ZYfHJcdXPKR9CbSmcKeVpURaHhEMpPB6K4x5ut3xxeEGSzeE5VRz8vixI4iqyHsD8rSdkLTPHy0iovUHOZQBAJVQ6hii9jpLhxUXmiTtH3jKzSj_f2fuNmZbIGhf-CR2FBeWF-aBPzEDEMV95nkCUMfW_Z2BmkbraSfvQZxkCO-cLrMAwlYcrzUtaJ7vnazeQB4sep5BBHBEvsa4kfq6_tz6BAKgv3R7cI2NkSv-wgy_IGoTjVCMTS8mJHGs_t8cWCO8-z4lxW1tUwIBKOCUDpmEEnGgiG6Sl0C_gGl4bZ5cDSl4IgPpcOVi9jZ7LA",
+              "token_type": "Bearer",
+              "issued_at": 1680888985929,
+              "expires_in": 28799,
+              "status": "approved",
+              "scope": "addresses international-prices subscriptions payments pickup tracking labels scan-forms companies service-delivery-standards locations international-labels prices",
+              "issuer": "https://api.usps.com/realms/USPS",
+              "client_id": "hyr7b3vCRtpYtAHM1a8cdUrkyyFmNkbg",
+              "application_name": "Silver Shipper Developer",
+              "api_products": "[Shipping-Silver]",
+              "public_key": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF4QWxwZjNSNEE1S0lwZnhJVWk1bgpMTFByZjZVZTV3MktzeGxSVzE1UWV0UzBjWGVxaW9OT2hXbDNaaVhEWEdKT3ZuK3RoY0NWVVQ3WC9JZWYvTENZCkhUWk1kYUJOdW55VHEwT2RNZmVkUU8zYUNKZmwvUnJPTHYyaG9TRDR4U1YxRzFuTTc1RTlRYitFZ1p0cmFEUXoKNW42SXRpMUMzOHFGMjU5NVRHUWVUemx3Wk1LQng1VTY2bGwzNzlkZ2plTUJxS3ppVHZHWEpOdVg5ZzRrRlBIaApTLzNERm9FNkVFSW8zUHExeDlXTnRaSm93VkRwQUVZZTQ3SU1UdXJDN2NGcXp2d3M1b1BDRHQ4c083N2lUdDN0Cm1vK3NrM2ExWnZSaGs2WUQ3Zkt1UldQVzFEYUM4dC9pazlnWnhqQndYNlZsSUhDRzRZSHlYejZteWdGV09jMmEKOVFJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t"
+          }
+
+     authorizationCodeTokenResponse:
+        summary: An access token and a new refresh token has been issued.  Indicates the refresh token count.
+        description: The public key provided should be used to verify the access token signature. The refresh token is an opaque value that is managed internally.
+        value:
+          {
+            "access_token": "eyJraWQiOiIxMDEwMTAiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIiLCJhdWQiOiJhZGRyZXNzZXMgaW50ZXJuYXRpb25hbC1wcmljZXMgc3Vic2NyaXB0aW9ucyBwYXltZW50cyBwaWNrdXAgdHJhY2tpbmcgbGFiZWxzIHNjYW4tZm9ybXMgY29tcGFuaWVzIHNlcnZpY2UtZGVsaXZlcnktc3RhbmRhcmRzIGxvY2F0aW9ucyBpbnRlcm5hdGlvbmFsLWxhYmVscyBwcmljZXMiLCJhenAiOiIiLCJtYWlsX293bmVycyI6IiIsInBheW1lbnRfYWNjb3VudHMiOiIiLCJpc3MiOiJ1cm46XC9cL2FwaS51c3BzLmNvbSIsImNvbnRyYWN0cyI6IiIsImV4cCI6MTY4MDkxODQyOCwiaWF0IjoxNjgwODg5NjI4LCJqdGkiOiI4ODQyOGNhNy1kMTE2LTQ1YWUtOWE2Ny1kMThkNDExOGJhNWQifQ.TTJh01hL8TGSyHTL4pf7ilAeTcAfndNGyhKdGs14jRzzV70PcqqGS3PZHLiCqq65LF3kJLGGniciNWH4dc3mVNPKmgvzcIWR73ezS-a_BDoxx9DmkqJF6ur4OsnsYQyKbhHqAf9iddnK4QRv6NN8fKHfBVmSCHEq4gcJ0zKV_HhBSE-DgeTWSOACeYt3zBRmuhfgwL40Eb9jV8cSdawyLGgQWEvvZoq7eai_f5gMJAcadLZ9Y-x_YSbJ0zUjU-J1kD-ngeogb66QoM1TYKIa_oqkFa6rtybZeeUZdmzxNLwj8ahQXy6EPA9qnPTdm1y03k-Mxh9O4JZPALDBNi5y1A",
+            "token_type": "Bearer",
+            "issued_at": 1680889628876,
+            "expires_in": 28799,
+            "status": "approved",
+            "scope": "addresses international-prices subscriptions payments pickup tracking labels scan-forms companies service-delivery-standards locations international-labels prices",
+            "issuer": "https://api.usps.com/realms/USPS",
+            "refresh_token": "hqhm7KuTJKzmvhCbRzKNbkgdFlw7kU18",
+            "refresh_token_issued_at": 1680889628876,
+            "refresh_token_status": "approved",
+            "refresh_token_expires_in": 604799,
+            "refresh_count": 1,
+            "client_id": "hyr7b3vCRtpYtAHM1a8cdUrkyyFmNkbg",
+            "application_name": "Silver Shipper Developer",
+            "api_products": "[Shipping-Silver]",
+            "public_key": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF4QWxwZjNSNEE1S0lwZnhJVWk1bgpMTFByZjZVZTV3MktzeGxSVzE1UWV0UzBjWGVxaW9OT2hXbDNaaVhEWEdKT3ZuK3RoY0NWVVQ3WC9JZWYvTENZCkhUWk1kYUJOdW55VHEwT2RNZmVkUU8zYUNKZmwvUnJPTHYyaG9TRDR4U1YxRzFuTTc1RTlRYitFZ1p0cmFEUXoKNW42SXRpMUMzOHFGMjU5NVRHUWVUemx3Wk1LQng1VTY2bGwzNzlkZ2plTUJxS3ppVHZHWEpOdVg5ZzRrRlBIaApTLzNERm9FNkVFSW8zUHExeDlXTnRaSm93VkRwQUVZZTQ3SU1UdXJDN2NGcXp2d3M1b1BDRHQ4c083N2lUdDN0Cm1vK3NrM2ExWnZSaGs2WUQ3Zkt1UldQVzFEYUM4dC9pazlnWnhqQndYNlZsSUhDRzRZSHlYejZteWdGV09jMmEKOVFJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t"
+        }
+ 
+          
+#  Resource Owner Password Credentials Flow omitted.
+
+     refreshTokenResponse:
+        summary: An access token and a new refresh token has been issued.  Indicates the refresh token count.
+        description: The public key provided should be used to verify the access token signature. The refresh token is an opaque value that is managed internally.
+        value:
+          {
+            "access_token": "eyJraWQiOiIxMDEwMTAiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIiLCJhdWQiOiJhZGRyZXNzZXMgaW50ZXJuYXRpb25hbC1wcmljZXMgc3Vic2NyaXB0aW9ucyBwYXltZW50cyBwaWNrdXAgdHJhY2tpbmcgbGFiZWxzIHNjYW4tZm9ybXMgY29tcGFuaWVzIHNlcnZpY2UtZGVsaXZlcnktc3RhbmRhcmRzIGxvY2F0aW9ucyBpbnRlcm5hdGlvbmFsLWxhYmVscyBwcmljZXMiLCJhenAiOiIiLCJtYWlsX293bmVycyI6IiIsInBheW1lbnRfYWNjb3VudHMiOiIiLCJpc3MiOiJ1cm46XC9cL2FwaS51c3BzLmNvbSIsImNvbnRyYWN0cyI6IiIsImV4cCI6MTY4MDkxODQyOCwiaWF0IjoxNjgwODg5NjI4LCJqdGkiOiI4ODQyOGNhNy1kMTE2LTQ1YWUtOWE2Ny1kMThkNDExOGJhNWQifQ.TTJh01hL8TGSyHTL4pf7ilAeTcAfndNGyhKdGs14jRzzV70PcqqGS3PZHLiCqq65LF3kJLGGniciNWH4dc3mVNPKmgvzcIWR73ezS-a_BDoxx9DmkqJF6ur4OsnsYQyKbhHqAf9iddnK4QRv6NN8fKHfBVmSCHEq4gcJ0zKV_HhBSE-DgeTWSOACeYt3zBRmuhfgwL40Eb9jV8cSdawyLGgQWEvvZoq7eai_f5gMJAcadLZ9Y-x_YSbJ0zUjU-J1kD-ngeogb66QoM1TYKIa_oqkFa6rtybZeeUZdmzxNLwj8ahQXy6EPA9qnPTdm1y03k-Mxh9O4JZPALDBNi5y1A",
+            "token_type": "Bearer",
+            "issued_at": 1680889628876,
+            "expires_in": 28799,
+            "status": "approved",
+            "scope": "addresses international-prices subscriptions payments pickup tracking labels scan-forms companies service-delivery-standards locations international-labels prices",
+            "issuer": "https://api.usps.com/realms/USPS",
+            "refresh_token": "hqhm7KuTJKzmvhCbRzKNbkgdFlw7kU18",
+            "refresh_token_issued_at": 1680889628876,
+            "refresh_token_status": "approved",
+            "refresh_token_expires_in": 604799,
+            "refresh_count": 1,
+            "client_id": "hyr7b3vCRtpYtAHM1a8cdUrkyyFmNkbg",
+            "application_name": "Silver Shipper Developer",
+            "api_products": "[Shipping-Silver]",
+            "public_key": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF4QWxwZjNSNEE1S0lwZnhJVWk1bgpMTFByZjZVZTV3MktzeGxSVzE1UWV0UzBjWGVxaW9OT2hXbDNaaVhEWEdKT3ZuK3RoY0NWVVQ3WC9JZWYvTENZCkhUWk1kYUJOdW55VHEwT2RNZmVkUU8zYUNKZmwvUnJPTHYyaG9TRDR4U1YxRzFuTTc1RTlRYitFZ1p0cmFEUXoKNW42SXRpMUMzOHFGMjU5NVRHUWVUemx3Wk1LQng1VTY2bGwzNzlkZ2plTUJxS3ppVHZHWEpOdVg5ZzRrRlBIaApTLzNERm9FNkVFSW8zUHExeDlXTnRaSm93VkRwQUVZZTQ3SU1UdXJDN2NGcXp2d3M1b1BDRHQ4c083N2lUdDN0Cm1vK3NrM2ExWnZSaGs2WUQ3Zkt1UldQVzFEYUM4dC9pazlnWnhqQndYNlZsSUhDRzRZSHlYejZteWdGV09jMmEKOVFJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t"
+          }
+          
+     invalidClientIdentifierResponse:
+       summary: Unknown client identifier.
+       description: The client identifier included in the request is missing, unknown or malformed.
+       value:
+          {
+            "error": "invalid_client",
+            "error_description": "InvalidApiKey: The client application credentials provided in the request are missing, invalid, inactive or not approved for access.",
+            "error_uri": "https://datatracker.ietf.org/doc/html/rfc6749#page-45"
+         }
+          
+     invalidClientCredentialsResponse:
+       summary:  Client authentication failed.
+       description: The client credentials included in the request could not be authenticated.
+       value:
+           {
+            "error": "invalid_client",
+            "error_description": "Client authentication failed.",
+            "error_uri": "https://datatracker.ietf.org/doc/html/rfc6749#page-45"
+           }
+           
+     invalidRefreshTokenResponse:
+       summary:  Invalid refresh token value.
+       description: The refresh token value included in the request is missing, already used or is malformed. The refresh token value may have been previously used to get an access token and is no longer valid.
+       value:
+           {
+            "error": "invalid_request",
+            "error_description": "Invalid Refresh Token: Check the value of the refresh token. It may be missing, have expired or have been revoked.",
+            "error_uri": "https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1",
+            "refresh_token": "Pvd2R5rrzCMKAeeV4yMfrNOtiVVWVZh",
+            "refresh_token_status": "Not Found"
+          }
+          
+     invalidRefreshTokenExpiredResponse:
+        summary: Expired refresh token.
+        description: The refresh token specified in the request is missing, invalid or has expired.
+        value:
+          {
+            "error": "invalid_request",
+            "error_description": "refresh_token_expired: Check the value of the refresh token. It may be missing, have expired or have been revoked.",
+            "error_uri": "https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1",
+            "refresh_token": "Pvd2R5rrzCMKAeeV4yMfrNOtiVVWVZh",
+            "refresh_token_status": "expired"
+          }
+          
+     invalidAuthorizationCodeResponse:
+        summary: Invalid Authorization Code.
+        description: The authorization code included in the request is invalid, expired or malformed.
+        value:
+           {
+              "error": "invalid_request",
+              "error_description": "Authorizaton Code Error: either the authorization code has expired, is invalid, or the redirect_uri is not registered.",
+              "error_uri": "https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1"
+          }
+          
+     spikeArrestViolationResponse:
+        summary:  Too many requests have been recieved from a given client in a short period of time.
+        description: The Retry-After header specifies the time after which requests may resume.
+        value:
+          {
+            "error": "invalid_request",
+            "error_description": "SpikeArrestViolation: Too many requests received from client in a short time.",
+            "error_uri": "https://datatracker.ietf.org/doc/html/rfc6585#section-4"
+          }
+ 
+     invalidRedirectUriResponse:
+        summary: The redirect URI is invalid.
+        description: The redirect URI value is not one that is registered to the client application making the request.
+        value:
+         {
+            "error": "invalid_request",
+            "error_description": "The redirect_uri is invalid.",
+            "error_uri": "https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"
+         }
+        
+     invalidBearerToken:
+        summary: The bearer token is invalid.
+        description: The bearer token must be included in the authorization header using the 'Bearer' authentication scheme.
+        value:
+          {
+            "error": "invalid_client",
+            "error_description": "Client authentication failed, reason InvalidToken.",
+            "error_uri": "https://datatracker.ietf.org/doc/html/rfc6749#page-45"
+          }
+          
+     unauthorizedClientApplication:
+        summary: Unauthorized Client Access.
+        description: The client application is not authorized to access the resource.
+        value:
+         {
+            "error": "unauthorized_client",
+            "error_description": "The client does not have access rights to the content.",
+            "error_uri": "https://datatracker.ietf.org/doc/html/rfc6749#section-5.2"
+         }

--- a/internal/server/address_validation.go
+++ b/internal/server/address_validation.go
@@ -13,10 +13,6 @@ import (
 // configured, it silently skips validation.
 // Returns a user-facing error message if the address is invalid, or empty string on success.
 func (s *Service) validateAndStandardizeAddress(ctx context.Context, addr *types.UserAddress) string {
-	if s.uspsClient == nil {
-		return ""
-	}
-
 	if addr.Address == nil || addr.State == nil {
 		return ""
 	}

--- a/internal/server/address_validation.go
+++ b/internal/server/address_validation.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"christjesus/internal/usps"
+	"christjesus/pkg/types"
+	"context"
+	"errors"
+	"strings"
+)
+
+// validateAndStandardizeAddress calls the USPS API to validate and standardize
+// the address fields on the given UserAddress. If USPS credentials are not
+// configured, it silently skips validation.
+// Returns a user-facing error message if the address is invalid, or empty string on success.
+func (s *Service) validateAndStandardizeAddress(ctx context.Context, addr *types.UserAddress) string {
+	if s.uspsClient == nil {
+		return ""
+	}
+
+	if addr.Address == nil || addr.State == nil {
+		return ""
+	}
+
+	input := usps.AddressInput{
+		StreetAddress: strings.TrimSpace(*addr.Address),
+		State:         strings.TrimSpace(*addr.State),
+	}
+	if addr.AddressExt != nil {
+		input.SecondaryAddress = strings.TrimSpace(*addr.AddressExt)
+	}
+	if addr.City != nil {
+		input.City = strings.TrimSpace(*addr.City)
+	}
+	if addr.ZipCode != nil {
+		input.ZIPCode = strings.TrimSpace(*addr.ZipCode)
+	}
+
+	result, err := s.uspsClient.ValidateAddress(ctx, input)
+	if err != nil {
+		var valErr *usps.ValidationError
+		if errors.As(err, &valErr) {
+			return valErr.Message
+		}
+		s.logger.WithError(err).Error("USPS address validation failed unexpectedly")
+		// Don't block the user on USPS outages — skip validation
+		return ""
+	}
+
+	// Overwrite with standardized values
+	addr.Address = &result.StreetAddress
+	if result.SecondaryAddress != "" {
+		addr.AddressExt = &result.SecondaryAddress
+	}
+	addr.City = &result.City
+	addr.State = &result.State
+	zip := result.ZIPCode
+	if result.ZIPPlus4 != "" {
+		zip = result.ZIPCode + "-" + result.ZIPPlus4
+	}
+	addr.ZipCode = &zip
+
+	return ""
+}

--- a/internal/server/address_validation_test.go
+++ b/internal/server/address_validation_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"christjesus/internal/usps"
+	"christjesus/pkg/types"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Run with: go test ./internal/server/ -run TestLiveAddressValidation -v
+// Requires USPS_CONSUMER_KEY and USPS_CONSUMER_SECRET in environment.
+func TestLiveAddressValidation(t *testing.T) {
+	key := os.Getenv("USPS_CONSUMER_KEY")
+	secret := os.Getenv("USPS_CONSUMER_SECRET")
+	if key == "" || secret == "" {
+		t.Skip("USPS_CONSUMER_KEY and USPS_CONSUMER_SECRET not set, skipping live test")
+	}
+
+	s := &Service{
+		uspsClient: usps.NewClient(key, secret),
+		logger:     logrus.New(),
+	}
+
+	t.Run("valid address gets standardized", func(t *testing.T) {
+		street := "101 Randolph Rd"
+		city := "Fort Mill"
+		state := "SC"
+		zip := "29715"
+
+		addr := &types.UserAddress{
+			Address: &street,
+			City:    &city,
+			State:   &state,
+			ZipCode: &zip,
+		}
+
+		errMsg := s.validateAndStandardizeAddress(context.Background(), addr)
+		if errMsg != "" {
+			t.Fatalf("unexpected validation error: %s", errMsg)
+		}
+
+		t.Logf("Standardized: %s, %s, %s %s", *addr.Address, *addr.City, *addr.State, *addr.ZipCode)
+	})
+
+	t.Run("bad address returns error", func(t *testing.T) {
+		street := "99999 Nonexistent Blvd"
+		city := "Faketown"
+		state := "NC"
+		zip := "00000"
+
+		addr := &types.UserAddress{
+			Address: &street,
+			City:    &city,
+			State:   &state,
+			ZipCode: &zip,
+		}
+
+		errMsg := s.validateAndStandardizeAddress(context.Background(), addr)
+		if errMsg == "" {
+			t.Fatal("expected validation error for bad address, got empty string")
+		}
+
+		t.Logf("Error (expected): %s", errMsg)
+	})
+}

--- a/internal/server/onboarding_location.go
+++ b/internal/server/onboarding_location.go
@@ -187,6 +187,25 @@ func (s *Service) handlePostOnboardingNeedLocation(w http.ResponseWriter, r *htt
 			IsPrimary:            setNewAsPrimary,
 		}
 
+		if validationErr := s.validateAndStandardizeAddress(ctx, selectedAddress); validationErr != "" {
+			data := &types.NeedLocationPageData{
+				BasePageData:      types.BasePageData{Title: "Need Location"},
+				ID:                needID,
+				Addresses:         addresses,
+				HasAddresses:      len(addresses) > 0,
+				SelectedAddressID: "new",
+				NewAddress:        location,
+				FormAction:        s.route(RouteOnboardingNeedLocation, map[string]string{"needID": needID}),
+				BackHref:          s.route(RouteOnboardingNeedWelcome, map[string]string{"needID": needID}),
+				Error:             validationErr,
+			}
+			if err := s.renderTemplate(w, r, "page.onboarding.need.location", data); err != nil {
+				s.logger.WithError(err).Error("failed to render need location page with validation error")
+				s.internalServerError(w)
+			}
+			return
+		}
+
 		err = s.userAddressRepo.Create(ctx, selectedAddress)
 		if err != nil {
 			s.logger.WithError(err).WithField("user_id", userID).Error("failed to create user address")

--- a/internal/server/onboarding_location.go
+++ b/internal/server/onboarding_location.go
@@ -5,6 +5,8 @@ import (
 	"christjesus/pkg/types"
 	"net/http"
 	"strings"
+
+	"github.com/k0kubun/pp/v3"
 )
 
 func (s *Service) handleGetOnboardingNeedLocation(w http.ResponseWriter, r *http.Request) {
@@ -120,6 +122,8 @@ func (s *Service) handlePostOnboardingNeedLocation(w http.ResponseWriter, r *htt
 	var selectedAddress *types.UserAddress
 	usesNonPrimaryAddress := false
 
+	pp.Print(selection)
+
 	if selection != "new" {
 		addressID := selection
 		if addressID == "" {
@@ -161,6 +165,8 @@ func (s *Service) handlePostOnboardingNeedLocation(w http.ResponseWriter, r *htt
 			s.internalServerError(w)
 			return
 		}
+
+		pp.Print("Location :: ", location)
 
 		if location.Address == nil || strings.TrimSpace(*location.Address) == "" ||
 			location.City == nil || strings.TrimSpace(*location.City) == "" ||

--- a/internal/server/profile_need_edit_location.go
+++ b/internal/server/profile_need_edit_location.go
@@ -176,6 +176,25 @@ func (s *Service) handlePostProfileNeedEditLocation(w http.ResponseWriter, r *ht
 			IsPrimary:            setNewAsPrimary,
 		}
 
+		if validationErr := s.validateAndStandardizeAddress(ctx, selectedAddress); validationErr != "" {
+			data := &types.NeedLocationPageData{
+				BasePageData:      types.BasePageData{Title: "Edit Need Location"},
+				ID:                needID,
+				Addresses:         addresses,
+				HasAddresses:      len(addresses) > 0,
+				SelectedAddressID: "new",
+				NewAddress:        location,
+				FormAction:        s.route(RouteProfileNeedEditLocation, map[string]string{"needID": needID}),
+				BackHref:          s.route(RouteProfileNeedReview, map[string]string{"needID": needID}),
+				Error:             validationErr,
+			}
+			if err := s.renderTemplate(w, r, "page.onboarding.need.location", data); err != nil {
+				s.logger.WithError(err).Error("failed to render profile need location edit page with validation error")
+				s.internalServerError(w)
+			}
+			return
+		}
+
 		err = s.userAddressRepo.Create(ctx, selectedAddress)
 		if err != nil {
 			s.logger.WithError(err).WithField("user_id", userID).Error("failed to create user address")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"christjesus/internal/store"
+	"christjesus/internal/usps"
 	"christjesus/pkg/types"
 
 	"github.com/alexedwards/flow"
@@ -37,6 +38,7 @@ type Service struct {
 
 	s3Client     *s3.Client
 	stripeClient *stripe.Client
+	uspsClient   *usps.Client
 
 	needsRepo                   *store.NeedRepository
 	progressRepo                *store.NeedProgressRepository
@@ -71,6 +73,7 @@ type Options struct {
 	Logger       *logrus.Logger
 	S3Client     *s3.Client
 	StripeClient *stripe.Client
+	USPSClient   *usps.Client
 
 	NeedsRepo                   *store.NeedRepository
 	ProgressRepo                *store.NeedProgressRepository
@@ -101,6 +104,7 @@ func New(opts Options) (*Service, error) {
 
 		s3Client:     opts.S3Client,
 		stripeClient: opts.StripeClient,
+		uspsClient:   opts.USPSClient,
 
 		needsRepo:                   opts.NeedsRepo,
 		progressRepo:                opts.ProgressRepo,

--- a/internal/server/templates/pages/onboarding/need/location.html
+++ b/internal/server/templates/pages/onboarding/need/location.html
@@ -20,7 +20,7 @@
   </div>
 
   {{if .Error}}
-  <div class="mb-4 rounded-md border border-[color:var(--cj-error)]/30 bg-[color:var(--cj-error)]/10 px-4 py-3 text-sm text-foreground">{{.Error}}</div>
+  <div class="mb-4 rounded-md border border-[color:var(--cj-error)] bg-[color:var(--cj-error)]/15 px-4 py-3 text-sm font-medium text-[color:var(--cj-error)]">{{.Error}}</div>
   {{end}}
 
   <div class="flex flex-col gap-6 rounded-xl border py-6 shadow-sm">

--- a/internal/server/templates/pages/onboarding/need/location.html
+++ b/internal/server/templates/pages/onboarding/need/location.html
@@ -19,6 +19,10 @@
     </div>
   </div>
 
+  {{if .Error}}
+  <div class="mb-4 rounded-md border border-[color:var(--cj-error)]/30 bg-[color:var(--cj-error)]/10 px-4 py-3 text-sm text-foreground">{{.Error}}</div>
+  {{end}}
+
   <div class="flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
     <form id="location-form" action="{{.FormAction}}" method="post" class="space-y-6 px-6">
       {{.CSRFField}}

--- a/internal/usps/client.go
+++ b/internal/usps/client.go
@@ -1,0 +1,238 @@
+package usps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	prodBaseURL  = "https://apis.usps.com"
+	tokenPath    = "/oauth2/v3/token"
+	addressPath  = "/addresses/v3/address"
+	tokenRefresh = 5 * time.Minute // refresh token this long before expiry
+)
+
+// Client is a USPS API client that handles OAuth2 token management
+// and address validation.
+type Client struct {
+	httpClient   *http.Client
+	baseURL      string
+	consumerKey  string
+	consumerSecret string
+
+	mu          sync.Mutex
+	accessToken string
+	tokenExpiry time.Time
+}
+
+// NewClient creates a new USPS API client.
+func NewClient(consumerKey, consumerSecret string) *Client {
+	return &Client{
+		httpClient:     &http.Client{Timeout: 10 * time.Second},
+		baseURL:        prodBaseURL,
+		consumerKey:    consumerKey,
+		consumerSecret: consumerSecret,
+	}
+}
+
+// tokenResponse represents the OAuth2 token response from USPS.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
+// getToken returns a valid access token, fetching a new one if necessary.
+func (c *Client) getToken(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.accessToken != "" && time.Now().Before(c.tokenExpiry) {
+		return c.accessToken, nil
+	}
+
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {c.consumerKey},
+		"client_secret": {c.consumerSecret},
+		"scope":         {"addresses"},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+tokenPath, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("usps: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("usps: token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("usps: read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("usps: token request returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tok tokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return "", fmt.Errorf("usps: parse token response: %w", err)
+	}
+
+	c.accessToken = tok.AccessToken
+	c.tokenExpiry = time.Now().Add(time.Duration(tok.ExpiresIn)*time.Second - tokenRefresh)
+
+	return c.accessToken, nil
+}
+
+// AddressInput is the input for address validation.
+type AddressInput struct {
+	StreetAddress    string
+	SecondaryAddress string
+	City             string
+	State            string
+	ZIPCode          string
+}
+
+// StandardizedAddress is the result of a successful address validation.
+type StandardizedAddress struct {
+	StreetAddress string
+	SecondaryAddress string
+	City          string
+	State         string
+	ZIPCode       string
+	ZIPPlus4      string
+}
+
+// addressResponse represents the USPS address validation API response.
+type addressResponse struct {
+	Address struct {
+		StreetAddress    string `json:"streetAddress"`
+		SecondaryAddress string `json:"secondaryAddress"`
+		City             string `json:"city"`
+		State            string `json:"state"`
+		ZIPCode          string `json:"ZIPCode"`
+		ZIPPlus4         string `json:"ZIPPlus4"`
+	} `json:"address"`
+}
+
+// errorResponse represents a USPS API error.
+type errorResponse struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// ValidationError is returned when USPS cannot validate the address.
+type ValidationError struct {
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
+// ValidateAddress validates and standardizes an address using the USPS API.
+// Returns a ValidationError if the address cannot be verified.
+func (c *Client) ValidateAddress(ctx context.Context, input AddressInput) (*StandardizedAddress, error) {
+	token, err := c.getToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	params := url.Values{
+		"streetAddress": {input.StreetAddress},
+		"state":         {input.State},
+	}
+	if input.SecondaryAddress != "" {
+		params.Set("secondaryAddress", input.SecondaryAddress)
+	}
+	if input.City != "" {
+		params.Set("city", input.City)
+	}
+	if input.ZIPCode != "" {
+		params.Set("ZIPCode", input.ZIPCode)
+	}
+
+	reqURL := c.baseURL + addressPath + "?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("usps: build address request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("usps: address request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("usps: read address response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		var addrResp addressResponse
+		if err := json.Unmarshal(body, &addrResp); err != nil {
+			return nil, fmt.Errorf("usps: parse address response: %w", err)
+		}
+
+		return &StandardizedAddress{
+			StreetAddress:    addrResp.Address.StreetAddress,
+			SecondaryAddress: addrResp.Address.SecondaryAddress,
+			City:             addrResp.Address.City,
+			State:            addrResp.Address.State,
+			ZIPCode:          addrResp.Address.ZIPCode,
+			ZIPPlus4:         addrResp.Address.ZIPPlus4,
+		}, nil
+	}
+
+	// Parse error response for user-friendly messages
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusNotFound {
+		var errResp errorResponse
+		if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error.Message != "" {
+			return nil, &ValidationError{Message: mapUSPSError(errResp.Error.Message)}
+		}
+		return nil, &ValidationError{Message: "We couldn't verify this address. Please check your entry and try again."}
+	}
+
+	return nil, fmt.Errorf("usps: address validation returned %d: %s", resp.StatusCode, string(body))
+}
+
+// mapUSPSError converts USPS error messages to user-friendly strings.
+func mapUSPSError(msg string) string {
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "address not found") || strings.Contains(lower, "no match"):
+		return "We couldn't find this address. Please check the street address, city, and state."
+	case strings.Contains(lower, "multiple addresses") || strings.Contains(lower, "more than one address"):
+		return "Multiple addresses match your entry. Please add more detail, such as an apartment or unit number."
+	case strings.Contains(lower, "insufficient"):
+		return "Not enough address information provided. Please fill in all required fields."
+	case strings.Contains(lower, "invalid delivery"):
+		return "This doesn't appear to be a valid delivery address. Please check your entry."
+	case strings.Contains(lower, "invalid") && strings.Contains(lower, "state"):
+		return "The state code is invalid. Please use a two-letter state abbreviation (e.g., NC, TX)."
+	case strings.Contains(lower, "invalid") && strings.Contains(lower, "city"):
+		return "The city name is invalid. Please check your entry."
+	case strings.Contains(lower, "city and state") && strings.Contains(lower, "unverifiable"):
+		return "We couldn't verify this city and state combination. Please check your entry."
+	default:
+		return "We couldn't verify this address. Please check your entry and try again."
+	}
+}

--- a/internal/usps/client_test.go
+++ b/internal/usps/client_test.go
@@ -1,0 +1,245 @@
+package usps
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidateAddress_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/v3/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: "test-token",
+			ExpiresIn:   3600,
+			TokenType:   "Bearer",
+		})
+	})
+	mux.HandleFunc("/addresses/v3/address", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("expected Bearer test-token, got %s", r.Header.Get("Authorization"))
+		}
+
+		q := r.URL.Query()
+		if q.Get("streetAddress") != "1600 Pennsylvania Ave" {
+			t.Errorf("unexpected streetAddress: %s", q.Get("streetAddress"))
+		}
+
+		resp := addressResponse{}
+		resp.Address.StreetAddress = "1600 PENNSYLVANIA AVE NW"
+		resp.Address.City = "WASHINGTON"
+		resp.Address.State = "DC"
+		resp.Address.ZIPCode = "20500"
+		resp.Address.ZIPPlus4 = "0005"
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewClient("test-key", "test-secret")
+	client.baseURL = srv.URL
+
+	result, err := client.ValidateAddress(context.Background(), AddressInput{
+		StreetAddress: "1600 Pennsylvania Ave",
+		City:          "Washington",
+		State:         "DC",
+		ZIPCode:       "20500",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.StreetAddress != "1600 PENNSYLVANIA AVE NW" {
+		t.Errorf("expected standardized street, got %s", result.StreetAddress)
+	}
+	if result.City != "WASHINGTON" {
+		t.Errorf("expected WASHINGTON, got %s", result.City)
+	}
+	if result.ZIPCode != "20500" {
+		t.Errorf("expected 20500, got %s", result.ZIPCode)
+	}
+	if result.ZIPPlus4 != "0005" {
+		t.Errorf("expected 0005, got %s", result.ZIPPlus4)
+	}
+}
+
+func TestValidateAddress_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/v3/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: "test-token",
+			ExpiresIn:   3600,
+			TokenType:   "Bearer",
+		})
+	})
+	mux.HandleFunc("/addresses/v3/address", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(errorResponse{
+			Error: struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			}{
+				Code:    "404",
+				Message: "There is no match for the address requested.",
+			},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewClient("test-key", "test-secret")
+	client.baseURL = srv.URL
+
+	_, err := client.ValidateAddress(context.Background(), AddressInput{
+		StreetAddress: "99999 Fake Street",
+		City:          "Nowhere",
+		State:         "ZZ",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	valErr := assertValidationError(t, err)
+
+	if !strings.Contains(valErr.Message, "couldn't find") {
+		t.Errorf("expected user-friendly message, got: %s", valErr.Message)
+	}
+}
+
+func TestValidateAddress_MultipleAddresses(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/v3/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: "test-token",
+			ExpiresIn:   3600,
+			TokenType:   "Bearer",
+		})
+	})
+	mux.HandleFunc("/addresses/v3/address", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(errorResponse{
+			Error: struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			}{
+				Code:    "404",
+				Message: "More than one address was found matching the requested address.",
+			},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewClient("test-key", "test-secret")
+	client.baseURL = srv.URL
+
+	_, err := client.ValidateAddress(context.Background(), AddressInput{
+		StreetAddress: "123 Main St",
+		City:          "Springfield",
+		State:         "IL",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	valErr := assertValidationError(t, err)
+
+	if !strings.Contains(valErr.Message, "Multiple addresses") {
+		t.Errorf("expected multiple addresses message, got: %s", valErr.Message)
+	}
+}
+
+func TestTokenCaching(t *testing.T) {
+	tokenCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/v3/token", func(w http.ResponseWriter, r *http.Request) {
+		tokenCalls++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: "test-token",
+			ExpiresIn:   3600,
+			TokenType:   "Bearer",
+		})
+	})
+	mux.HandleFunc("/addresses/v3/address", func(w http.ResponseWriter, r *http.Request) {
+		resp := addressResponse{}
+		resp.Address.StreetAddress = "123 MAIN ST"
+		resp.Address.City = "ANYTOWN"
+		resp.Address.State = "VA"
+		resp.Address.ZIPCode = "22030"
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewClient("test-key", "test-secret")
+	client.baseURL = srv.URL
+
+	input := AddressInput{
+		StreetAddress: "123 Main St",
+		City:          "Anytown",
+		State:         "VA",
+	}
+
+	// Make two calls — token should be fetched only once
+	if _, err := client.ValidateAddress(context.Background(), input); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := client.ValidateAddress(context.Background(), input); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	if tokenCalls != 1 {
+		t.Errorf("expected 1 token call, got %d", tokenCalls)
+	}
+}
+
+func TestMapUSPSError(t *testing.T) {
+	tests := []struct {
+		input    string
+		contains string
+	}{
+		{"There is no match for the address requested.", "couldn't find"},
+		{"Address not found.", "couldn't find"},
+		{"More than one address was found matching the requested address.", "Multiple addresses"},
+		{"The address information in the request is insufficient to match.", "Not enough"},
+		{"The address requested is an invalid delivery address.", "valid delivery"},
+		{"The state code in the request is missing or invalid.", "state code"},
+		{"The city in the request is missing or invalid.", "city name"},
+		{"The city and state are missing or together unverifiable.", "city and state"},
+		{"Some unknown error.", "couldn't verify"},
+	}
+
+	for _, tt := range tests {
+		result := mapUSPSError(tt.input)
+		if !strings.Contains(result, tt.contains) {
+			t.Errorf("mapUSPSError(%q) = %q, expected to contain %q", tt.input, result, tt.contains)
+		}
+	}
+}
+
+func assertValidationError(t *testing.T, err error) *ValidationError {
+	t.Helper()
+	var valErr *ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+	return valErr
+}

--- a/internal/usps/integration_test.go
+++ b/internal/usps/integration_test.go
@@ -1,0 +1,47 @@
+package usps_test
+
+import (
+	"christjesus/internal/usps"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Run with: go test ./internal/usps/ -run TestLiveValidation -v
+// Requires USPS_CONSUMER_KEY and USPS_CONSUMER_SECRET in environment.
+func TestLiveValidation(t *testing.T) {
+	key := os.Getenv("USPS_CONSUMER_KEY")
+	secret := os.Getenv("USPS_CONSUMER_SECRET")
+	if key == "" || secret == "" {
+		t.Skip("USPS_CONSUMER_KEY and USPS_CONSUMER_SECRET not set, skipping live test")
+	}
+
+	client := usps.NewClient(key, secret)
+
+	t.Run("valid address", func(t *testing.T) {
+		result, err := client.ValidateAddress(context.Background(), usps.AddressInput{
+			StreetAddress: "1600 Pennsylvania Ave",
+			City:          "Washington",
+			State:         "DC",
+			ZIPCode:       "20500",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		fmt.Printf("Standardized: %s, %s, %s %s-%s\n",
+			result.StreetAddress, result.City, result.State, result.ZIPCode, result.ZIPPlus4)
+	})
+
+	t.Run("bad address", func(t *testing.T) {
+		_, err := client.ValidateAddress(context.Background(), usps.AddressInput{
+			StreetAddress: "99999 Nonexistent Blvd",
+			City:          "Faketown",
+			State:         "ZZ",
+		})
+		if err == nil {
+			t.Fatal("expected error for bad address, got nil")
+		}
+		fmt.Printf("Error (expected): %v\n", err)
+	})
+}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -39,6 +39,10 @@ type Config struct {
 	TigrisAccessKey      string `envconfig:"TIGRIS_ACCESS_KEY"`
 	TigrisSecretKey      string `envconfig:"TIGRIS_SECRET_KEY"`
 
+	// USPS Address Validation API (OAuth2 client credentials)
+	USPSConsumerKey    string `envconfig:"USPS_CONSUMER_KEY"`
+	USPSConsumerSecret string `envconfig:"USPS_CONSUMER_SECRET"`
+
 	// Auth Configuration
 	CookieName       string `envconfig:"SESSION_COOKIE_NAME" default:"session_id"`
 	SessionMaxAgeSec int    `envconfig:"SESSION_MAX_AGE_SEC" default:"604800"` // 7 days

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -40,8 +40,8 @@ type Config struct {
 	TigrisSecretKey      string `envconfig:"TIGRIS_SECRET_KEY"`
 
 	// USPS Address Validation API (OAuth2 client credentials)
-	USPSConsumerKey    string `envconfig:"USPS_CONSUMER_KEY"`
-	USPSConsumerSecret string `envconfig:"USPS_CONSUMER_SECRET"`
+	USPSConsumerKey    string `envconfig:"USPS_CONSUMER_KEY" required:"true"`
+	USPSConsumerSecret string `envconfig:"USPS_CONSUMER_SECRET" required:"true"`
 
 	// Auth Configuration
 	CookieName       string `envconfig:"SESSION_COOKIE_NAME" default:"session_id"`

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -284,6 +284,7 @@ type NeedLocationPageData struct {
 	NewAddress        *UserAddressForm
 	FormAction        string
 	BackHref          string
+	Error             string
 }
 
 type NeedSubmittedPageData struct {


### PR DESCRIPTION
## Summary
- Add USPS API client (`internal/usps/`) with OAuth2 client credentials flow and in-memory token caching
- Validate and standardize addresses via `GET /addresses/v3/address` when creating or editing need locations
- Replace user-entered address fields with USPS-standardized values (street, city, state, ZIP+4) on success
- Display user-friendly error messages when USPS rejects an address (not found, multiple matches, invalid delivery, etc.)
- Gracefully skip validation on USPS outages so users aren't blocked

## Test plan
- [x] Unit tests for USPS client: address validation, error mapping, token caching
- [x] Manual test: submit a valid address and verify it gets standardized (uppercased street, ZIP+4 appended)
- [x] Manual test: submit a bogus address and verify error banner appears on the location form
- [x] Manual test: edit a need's location and verify validation runs on the edit flow too
- [x] Verify `USPS_CONSUMER_KEY` and `USPS_CONSUMER_SECRET` are set as Fly secrets before deploying

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)