### PR TITLE
feat: add geospatial ZIP code search to browse needs page

### DIFF
--- a/cmd/christjesus/import_zips.go
+++ b/cmd/christjesus/import_zips.go
@@ -170,7 +170,9 @@ func parseZCTAFile(r io.Reader) ([]zipCentroid, error) {
 	return rows, nil
 }
 
-func loadZipCentroids(ctx context.Context, pool interface{ Begin(ctx context.Context) (pgx.Tx, error) }, rows []zipCentroid) error {
+func loadZipCentroids(ctx context.Context, pool interface {
+	Begin(ctx context.Context) (pgx.Tx, error)
+}, rows []zipCentroid) error {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
@@ -193,10 +195,20 @@ func loadZipCentroids(ctx context.Context, pool interface{ Begin(ctx context.Con
 		return fmt.Errorf("copy into zip_centroids: %w", err)
 	}
 
+	logrus.WithField("copied", copyCount).Info("COPY complete, populating geography column")
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE christjesus.zip_centroids
+		SET geog = ST_SetSRID(ST_MakePoint(longitude::float8, latitude::float8), 4326)::geography
+		WHERE geog IS NULL
+	`); err != nil {
+		return fmt.Errorf("populate geog column: %w", err)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
 
-	logrus.WithField("copied", copyCount).Info("COPY complete")
+	logrus.WithField("copied", copyCount).Info("zip_centroids table populated with geography data")
 	return nil
 }

--- a/cmd/christjesus/seed.go
+++ b/cmd/christjesus/seed.go
@@ -49,6 +49,7 @@ var seedCommand = &cli.Command{
 		assignmentRepo := store.NewAssignmentRepository(pool)
 		storyRepo := store.NewStoryRepository(pool)
 		userRepo := store.NewUserRepository(pool)
+		addressRepo := store.NewUserAddressRepository(pool)
 
 		// Seed categories
 		logrus.Info("Seeding categories...")
@@ -63,7 +64,7 @@ var seedCommand = &cli.Command{
 
 		if fakeNeedsCount > 0 {
 			logrus.Info("Seeding fake users...")
-			if err := seed.SeedFakeUsers(ctx, userRepo); err != nil {
+			if err := seed.SeedFakeUsers(ctx, userRepo, addressRepo); err != nil {
 				return fmt.Errorf("failed to seed fake users: %w", err)
 			}
 			logrus.Info("Fake users seeded successfully")

--- a/internal/seed/users.go
+++ b/internal/seed/users.go
@@ -15,17 +15,20 @@ type fakeUserSeed struct {
 	GivenName  string
 	FamilyName string
 	UserType   types.UserType
+	ZipCode    string
+	City       string
+	State      string
 }
 
 var fakeUsers = []fakeUserSeed{
-	{ID: "11111111-1111-1111-1111-111111111111", Email: "ava.williams+seed1@example.com", GivenName: "Ava", FamilyName: "Williams", UserType: types.UserTypeRecipient},
-	{ID: "22222222-2222-2222-2222-222222222222", Email: "liam.johnson+seed2@example.com", GivenName: "Liam", FamilyName: "Johnson", UserType: types.UserTypeRecipient},
-	{ID: "33333333-3333-3333-3333-333333333333", Email: "noah.brown+seed3@example.com", GivenName: "Noah", FamilyName: "Brown", UserType: types.UserTypeRecipient},
-	{ID: "44444444-4444-4444-4444-444444444444", Email: "mia.davis+seed4@example.com", GivenName: "Mia", FamilyName: "Davis", UserType: types.UserTypeRecipient},
-	{ID: "55555555-5555-5555-5555-555555555555", Email: "elijah.garcia+seed5@example.com", GivenName: "Elijah", FamilyName: "Garcia", UserType: types.UserTypeRecipient},
-	{ID: "66666666-6666-6666-6666-666666666666", Email: "olivia.miller+seed6@example.com", GivenName: "Olivia", FamilyName: "Miller", UserType: types.UserTypeRecipient},
-	{ID: "77777777-7777-7777-7777-777777777777", Email: "ethan.moore+seed7@example.com", GivenName: "Ethan", FamilyName: "Moore", UserType: types.UserTypeRecipient},
-	{ID: "88888888-8888-8888-8888-888888888888", Email: "sophia.taylor+seed8@example.com", GivenName: "Sophia", FamilyName: "Taylor", UserType: types.UserTypeRecipient},
+	{ID: "11111111-1111-1111-1111-111111111111", Email: "ava.williams+seed1@example.com", GivenName: "Ava", FamilyName: "Williams", UserType: types.UserTypeRecipient, ZipCode: "28202", City: "Charlotte", State: "NC"},
+	{ID: "22222222-2222-2222-2222-222222222222", Email: "liam.johnson+seed2@example.com", GivenName: "Liam", FamilyName: "Johnson", UserType: types.UserTypeRecipient, ZipCode: "28205", City: "Charlotte", State: "NC"},
+	{ID: "33333333-3333-3333-3333-333333333333", Email: "noah.brown+seed3@example.com", GivenName: "Noah", FamilyName: "Brown", UserType: types.UserTypeRecipient, ZipCode: "28208", City: "Charlotte", State: "NC"},
+	{ID: "44444444-4444-4444-4444-444444444444", Email: "mia.davis+seed4@example.com", GivenName: "Mia", FamilyName: "Davis", UserType: types.UserTypeRecipient, ZipCode: "28210", City: "Charlotte", State: "NC"},
+	{ID: "55555555-5555-5555-5555-555555555555", Email: "elijah.garcia+seed5@example.com", GivenName: "Elijah", FamilyName: "Garcia", UserType: types.UserTypeRecipient, ZipCode: "28216", City: "Charlotte", State: "NC"},
+	{ID: "66666666-6666-6666-6666-666666666666", Email: "olivia.miller+seed6@example.com", GivenName: "Olivia", FamilyName: "Miller", UserType: types.UserTypeRecipient, ZipCode: "28269", City: "Charlotte", State: "NC"},
+	{ID: "77777777-7777-7777-7777-777777777777", Email: "ethan.moore+seed7@example.com", GivenName: "Ethan", FamilyName: "Moore", UserType: types.UserTypeRecipient, ZipCode: "28277", City: "Charlotte", State: "NC"},
+	{ID: "88888888-8888-8888-8888-888888888888", Email: "sophia.taylor+seed8@example.com", GivenName: "Sophia", FamilyName: "Taylor", UserType: types.UserTypeRecipient, ZipCode: "28203", City: "Charlotte", State: "NC"},
 }
 
 func seedFakeNeedUserIDs() []string {
@@ -38,7 +41,7 @@ func seedFakeNeedUserIDs() []string {
 	return ids
 }
 
-func SeedFakeUsers(ctx context.Context, userRepo *store.UserRepository) error {
+func SeedFakeUsers(ctx context.Context, userRepo *store.UserRepository, addressRepo *store.UserAddressRepository) error {
 	seeded := 0
 	for _, fakeUser := range fakeUsers {
 		existing, err := userRepo.User(ctx, fakeUser.ID)
@@ -60,19 +63,35 @@ func SeedFakeUsers(ctx context.Context, userRepo *store.UserRepository) error {
 				return fmt.Errorf("failed to create fake user %s: %w", fakeUser.ID, err)
 			}
 			seeded++
-			continue
+		} else {
+			userType := string(fakeUser.UserType)
+			existing.UserType = &userType
+			existing.Email = utils.StringPtr(fakeUser.Email)
+			existing.GivenName = utils.StringPtr(fakeUser.GivenName)
+			existing.FamilyName = utils.StringPtr(fakeUser.FamilyName)
+
+			if err := userRepo.Update(ctx, fakeUser.ID, existing); err != nil {
+				return fmt.Errorf("failed to update fake user %s: %w", fakeUser.ID, err)
+			}
+			seeded++
 		}
 
-		userType := string(fakeUser.UserType)
-		existing.UserType = &userType
-		existing.Email = utils.StringPtr(fakeUser.Email)
-		existing.GivenName = utils.StringPtr(fakeUser.GivenName)
-		existing.FamilyName = utils.StringPtr(fakeUser.FamilyName)
-
-		if err := userRepo.Update(ctx, fakeUser.ID, existing); err != nil {
-			return fmt.Errorf("failed to update fake user %s: %w", fakeUser.ID, err)
+		// Seed a primary address if the user doesn't already have one
+		if fakeUser.ZipCode != "" {
+			primaryAddr, _ := addressRepo.PrimaryByUserID(ctx, fakeUser.ID)
+			if primaryAddr == nil {
+				addr := &types.UserAddress{
+					ID:      utils.NanoID(),
+					UserID:  fakeUser.ID,
+					City:    utils.StringPtr(fakeUser.City),
+					State:   utils.StringPtr(fakeUser.State),
+					ZipCode: utils.StringPtr(fakeUser.ZipCode),
+				}
+				if err := addressRepo.CreateAsPrimary(ctx, addr); err != nil {
+					return fmt.Errorf("failed to create address for fake user %s: %w", fakeUser.ID, err)
+				}
+			}
 		}
-		seeded++
 	}
 
 	fmt.Printf("Fake users seeded: %d upserted\n", seeded)

--- a/internal/server/admin_need_explorer.go
+++ b/internal/server/admin_need_explorer.go
@@ -52,8 +52,6 @@ func (s *Service) handleGetAdminNeedExplorer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-
-
 	items := make([]*types.AdminNeedExplorerItem, 0, len(needs))
 	for _, need := range needs {
 		if need == nil {

--- a/internal/server/pages.go
+++ b/internal/server/pages.go
@@ -338,6 +338,24 @@ func (s *Service) handleBrowse(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	filters := parseBrowseFilters(r.URL.Query())
 
+	// Pre-populate ZIP/radius from donor preferences if logged in and no query params set
+	if filters.ZipCode == "" {
+		if session, ok := sessionFromContext(ctx); ok && session.UserID != "" {
+			pref, err := s.donorPreferenceRepo.ByUserID(ctx, session.UserID)
+			if err != nil {
+				s.logger.WithError(err).Warn("failed to fetch donor preferences for browse pre-population")
+			}
+			if pref != nil {
+				if pref.ZipCode != nil && *pref.ZipCode != "" {
+					filters.ZipCode = *pref.ZipCode
+				}
+				if pref.Radius != nil && *pref.Radius != "" {
+					filters.Radius = normalizeBrowseRadius(*pref.Radius)
+				}
+			}
+		}
+	}
+
 	if isHXRequest(r) {
 		data, err := s.buildBrowseResultsPageData(ctx, filters)
 		if err != nil {
@@ -366,15 +384,9 @@ func (s *Service) handleBrowse(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cityOptions := []string{}
-	if filters.City != "" {
-		cityOptions = append(cityOptions, filters.City)
-	}
-
 	data := &types.BrowsePageData{
 		BasePageData:         types.BasePageData{Title: "Browse Needs"},
 		Categories:           categories,
-		Cities:               cityOptions,
 		Filters:              filters,
 		LoadResultsOnRender:  true,
 		ShowResultsSkeletons: true,
@@ -412,14 +424,15 @@ func parseBrowseFilters(query url.Values) types.BrowseFilters {
 
 	return types.BrowseFilters{
 		Search:      strings.TrimSpace(query.Get("search")),
-		City:        strings.TrimSpace(query.Get("city")),
+		ZipCode:     normalizeBrowseZipCode(query.Get("zip")),
+		Radius:      normalizeBrowseRadius(query.Get("radius")),
 		CategoryIDs: selectedCategories,
 		Urgency:     strings.TrimSpace(query.Get("urgency")),
-		FundingMax:      fundingMax,
-		ViewMode:        normalizeBrowseViewMode(query.Get("view")),
-		SortBy:          normalizeBrowseSortBy(query.Get("sort")),
-		Page:            parsePositiveInt(query.Get("page"), 1),
-		PageSize:        browseDefaultPageSize,
+		FundingMax:  fundingMax,
+		ViewMode:    normalizeBrowseViewMode(query.Get("view")),
+		SortBy:      normalizeBrowseSortBy(query.Get("sort")),
+		Page:        parsePositiveInt(query.Get("page"), 1),
+		PageSize:    browseDefaultPageSize,
 	}
 }
 
@@ -429,6 +442,33 @@ func normalizeBrowseViewMode(raw string) string {
 		return "list"
 	default:
 		return "grid"
+	}
+}
+
+func normalizeBrowseZipCode(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) != 5 {
+		return ""
+	}
+	for _, c := range trimmed {
+		if c < '0' || c > '9' {
+			return ""
+		}
+	}
+	return trimmed
+}
+
+func normalizeBrowseRadius(raw string) string {
+	// Accept both "15" and "15-miles" (donor_preferences format)
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.TrimSuffix(trimmed, "-miles")
+	switch trimmed {
+	case "5", "15", "25", "50":
+		return trimmed
+	case "anywhere":
+		return "anywhere"
+	default:
+		return ""
 	}
 }
 
@@ -445,14 +485,13 @@ func isHXRequest(r *http.Request) bool {
 	return strings.EqualFold(r.Header.Get("HX-Request"), "true")
 }
 
-func browseStoreFilter(filters types.BrowseFilters) store.BrowseNeedsFilter {
+func (s *Service) browseStoreFilter(filters types.BrowseFilters) store.BrowseNeedsFilter {
 	categoryIDs := make([]string, 0, len(filters.CategoryIDs))
 	for id := range filters.CategoryIDs {
 		categoryIDs = append(categoryIDs, id)
 	}
 
-	return store.BrowseNeedsFilter{
-		City:        filters.City,
+	sf := store.BrowseNeedsFilter{
 		CategoryIDs: categoryIDs,
 		Urgency:     filters.Urgency,
 		FundingMax:  filters.FundingMax,
@@ -461,10 +500,21 @@ func browseStoreFilter(filters types.BrowseFilters) store.BrowseNeedsFilter {
 		Page:        filters.Page,
 		PageSize:    filters.PageSize,
 	}
+
+	if filters.ZipCode != "" {
+		sf.ZipCode = filters.ZipCode
+		if filters.Radius != "" && filters.Radius != "anywhere" {
+			if radiusMiles, err := strconv.ParseFloat(filters.Radius, 64); err == nil {
+				sf.RadiusMiles = &radiusMiles
+			}
+		}
+	}
+
+	return sf
 }
 
 func (s *Service) buildBrowseResultsPageData(ctx context.Context, filters types.BrowseFilters) (*types.BrowsePageData, error) {
-	sf := browseStoreFilter(filters)
+	sf := s.browseStoreFilter(filters)
 
 	totalNeeds, err := s.needsRepo.BrowseNeedsCount(ctx, sf)
 	if err != nil {
@@ -483,12 +533,22 @@ func (s *Service) buildBrowseResultsPageData(ctx context.Context, filters types.
 		sf.Page = totalPages
 	}
 
-	needs, err := s.needsRepo.BrowseNeedsPage(ctx, sf)
+	rows, err := s.needsRepo.BrowseNeedsPage(ctx, sf)
 	if err != nil {
 		return nil, err
 	}
 
+	needs := make([]*types.Need, 0, len(rows))
+	distanceByNeedID := make(map[string]*float64, len(rows))
+	for _, row := range rows {
+		needs = append(needs, &row.Need)
+		distanceByNeedID[row.Need.ID] = row.DistanceMiles
+	}
+
 	cards := s.buildNeedCards(ctx, needs, "browse needs")
+	for _, card := range cards {
+		card.DistanceMiles = distanceByNeedID[card.ID]
+	}
 
 	categories, err := s.categoryRepo.Categories(ctx)
 	if err != nil {
@@ -526,8 +586,11 @@ func (s *Service) buildBrowsePageHref(filters types.BrowseFilters, page int) str
 	if filters.Search != "" {
 		v.Set("search", filters.Search)
 	}
-	if filters.City != "" {
-		v.Set("city", filters.City)
+	if filters.ZipCode != "" {
+		v.Set("zip", filters.ZipCode)
+	}
+	if filters.Radius != "" {
+		v.Set("radius", filters.Radius)
 	}
 	for id := range filters.CategoryIDs {
 		v.Add("category", id)
@@ -565,7 +628,6 @@ func (s *Service) handleNeedDetail(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-
 
 	ownerName := "Anonymous"
 	user, err := s.userRepo.User(ctx, need.UserID)
@@ -710,9 +772,9 @@ func (s *Service) handleNeedDetail(w http.ResponseWriter, r *http.Request) {
 		OwnerName:           ownerName,
 		SelectedAddress:     selectedAddress,
 		CityState:           cityState,
-		UrgencyLabel:    urgencyLabel,
-		UrgencyDotClass: urgencyDotClass,
-		FundingPercent:  fundingPercent,
+		UrgencyLabel:        urgencyLabel,
+		UrgencyDotClass:     urgencyDotClass,
+		FundingPercent:      fundingPercent,
 		Story:               story,
 		PrimaryCategory:     primaryCategory,
 		SecondaryCategories: secondaryCategories,

--- a/internal/server/templates/components/filters-panel.html
+++ b/internal/server/templates/components/filters-panel.html
@@ -13,13 +13,17 @@
   -->
 
   <div>
-    <p class="text-sm font-semibold text-foreground">City</p>
-    <select name="city"
-      class="mt-2 flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50">
-      <option value="">All cities</option>
-      {{range .Cities}}
-      <option value="{{.}}" {{if eq $.Filters.City .}}selected{{end}}>{{.}}</option>
-      {{end}}
+    <p class="text-sm font-semibold text-foreground">Location</p>
+    <input type="text" name="zip" value="{{.Filters.ZipCode}}" placeholder="ZIP code (e.g. 28202)" maxlength="5" inputmode="numeric" pattern="\d{5}"
+      class="mt-2 flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring" />
+    <select name="radius"
+      class="mt-2 flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring">
+      <option value="">Select radius</option>
+      <option value="5" {{if eq .Filters.Radius "5"}}selected{{end}}>5 miles</option>
+      <option value="15" {{if eq .Filters.Radius "15"}}selected{{end}}>15 miles</option>
+      <option value="25" {{if eq .Filters.Radius "25"}}selected{{end}}>25 miles</option>
+      <option value="50" {{if eq .Filters.Radius "50"}}selected{{end}}>50 miles</option>
+      <option value="anywhere" {{if eq .Filters.Radius "anywhere"}}selected{{end}}>Anywhere</option>
     </select>
   </div>
 

--- a/internal/server/templates/components/need-card.html
+++ b/internal/server/templates/components/need-card.html
@@ -4,6 +4,7 @@
     <p class="text-3xl font-semibold leading-none text-foreground">{{.OwnerName}}</p>
     <div class="flex items-center gap-2 text-sm text-muted-foreground">
       <span>{{.CityState}}</span>
+      {{if .DistanceMiles}}<span>•</span><span>~{{printf "%.0f" .DistanceMiles}} mi</span>{{end}}
       <span>•</span>
       <span class="h-2.5 w-2.5 rounded-full {{.UrgencyDotClass}}"></span>
       <span class="font-medium uppercase tracking-wide">{{.UrgencyLabel}}</span>

--- a/internal/store/need.go
+++ b/internal/store/need.go
@@ -60,9 +60,10 @@ func (r *NeedRepository) Need(ctx context.Context, needID string) (*types.Need, 
 }
 
 type BrowseNeedsFilter struct {
-	City        string
+	ZipCode     string
+	RadiusMiles *float64
 	CategoryIDs []string
-	Urgency string
+	Urgency     string
 	FundingMax  int
 	Search      string
 	SortBy      string
@@ -70,12 +71,18 @@ type BrowseNeedsFilter struct {
 	PageSize    int
 }
 
+type BrowseNeedRow struct {
+	types.Need
+	DistanceMiles *float64 `db:"distance_miles"`
+}
+
 const (
 	browseFromClause = needTableName + " n"
 
-	browseJoinSelectedAddr = "christjesus.user_addresses sa ON sa.id = n.user_address_id"
-	browseJoinPrimaryAddr  = "christjesus.user_addresses pa ON pa.user_id = n.user_id AND pa.is_primary = true AND n.user_address_id IS NULL"
+	browseJoinSelectedAddr    = "christjesus.user_addresses sa ON sa.id = n.user_address_id"
+	browseJoinPrimaryAddr     = "christjesus.user_addresses pa ON pa.user_id = n.user_id AND pa.is_primary = true AND n.user_address_id IS NULL"
 	browseJoinPrimaryCategory = "christjesus.need_category_assignments nca ON nca.need_id = n.id AND nca.is_primary = true"
+	browseJoinZipCentroid     = "christjesus.zip_centroids zc ON zc.zip_code = COALESCE(sa.zip_code, pa.zip_code)"
 
 	browseFundingPercentExpr = "CASE WHEN n.amount_needed_cents > 0 THEN (n.amount_raised_cents * 100 / n.amount_needed_cents) ELSE 0 END"
 	browseUrgencyWeightExpr  = "CASE WHEN n.amount_needed_cents <= 0 THEN 1 WHEN (n.amount_raised_cents * 100 / n.amount_needed_cents) < 35 THEN 3 WHEN (n.amount_raised_cents * 100 / n.amount_needed_cents) < 70 THEN 2 ELSE 1 END"
@@ -87,13 +94,27 @@ func browseBaseQuery(columns ...string) sq.SelectBuilder {
 		LeftJoin(browseJoinSelectedAddr).
 		LeftJoin(browseJoinPrimaryAddr).
 		LeftJoin(browseJoinPrimaryCategory).
+		LeftJoin(browseJoinZipCentroid).
 		Where(sq.Eq{"n.status": []types.NeedStatus{types.NeedStatusActive, types.NeedStatusFunded}}).
 		Where(sq.Eq{"n.deleted_at": nil})
 }
 
 func applyBrowseFilters(qb sq.SelectBuilder, f BrowseNeedsFilter) sq.SelectBuilder {
-	if f.City != "" {
-		qb = qb.Where("LOWER(COALESCE(sa.city, pa.city)) = LOWER(?)", f.City)
+	donorGeogSubquery := "(SELECT geog FROM christjesus.zip_centroids WHERE zip_code = ?)"
+	if f.ZipCode != "" {
+		qb = qb.Column(
+			fmt.Sprintf("ST_Distance(zc.geog, %s) / 1609.344 AS distance_miles", donorGeogSubquery),
+			f.ZipCode,
+		)
+		if f.RadiusMiles != nil {
+			radiusMeters := *f.RadiusMiles * 1609.344
+			qb = qb.Where(
+				fmt.Sprintf("(zc.geog IS NULL OR ST_DWithin(zc.geog, %s, ?))", donorGeogSubquery),
+				f.ZipCode, radiusMeters,
+			)
+		}
+	} else {
+		qb = qb.Column("NULL::float8 AS distance_miles")
 	}
 	if len(f.CategoryIDs) > 0 {
 		qb = qb.Where(sq.Eq{"nca.category_id": f.CategoryIDs})
@@ -117,7 +138,7 @@ func applyBrowseFilters(qb sq.SelectBuilder, f BrowseNeedsFilter) sq.SelectBuild
 	return qb
 }
 
-func (r *NeedRepository) BrowseNeedsPage(ctx context.Context, f BrowseNeedsFilter) ([]*types.Need, error) {
+func (r *NeedRepository) BrowseNeedsPage(ctx context.Context, f BrowseNeedsFilter) ([]*BrowseNeedRow, error) {
 	if f.Page < 1 {
 		f.Page = 1
 	}
@@ -136,10 +157,12 @@ func (r *NeedRepository) BrowseNeedsPage(ctx context.Context, f BrowseNeedsFilte
 	switch f.SortBy {
 	case "newest":
 		qb = qb.OrderBy("n.created_at DESC")
+	case "nearest":
+		qb = qb.OrderBy("distance_miles ASC NULLS LAST", "n.created_at DESC")
 	case "closest":
-		qb = qb.OrderBy(browseFundingPercentExpr + " DESC", "n.created_at DESC")
+		qb = qb.OrderBy(browseFundingPercentExpr+" DESC", "n.created_at DESC")
 	default: // "urgency"
-		qb = qb.OrderBy(browseUrgencyWeightExpr + " DESC", "n.created_at DESC")
+		qb = qb.OrderBy(browseUrgencyWeightExpr+" DESC", "n.created_at DESC")
 	}
 
 	offset := uint64((f.Page - 1) * f.PageSize)
@@ -151,16 +174,16 @@ func (r *NeedRepository) BrowseNeedsPage(ctx context.Context, f BrowseNeedsFilte
 		return nil, fmt.Errorf("failed to generate browse needs page query: %w", err)
 	}
 
-	needs := make([]*types.Need, 0)
-	err = pgxscan.Select(ctx, r.pool, &needs, query, args...)
+	rows := make([]*BrowseNeedRow, 0)
+	err = pgxscan.Select(ctx, r.pool, &rows, query, args...)
 	if err != nil {
 		if pgxscan.NotFound(err) {
-			return needs, nil
+			return rows, nil
 		}
 		return nil, fmt.Errorf("failed to fetch browse needs page: %w", err)
 	}
 
-	return needs, nil
+	return rows, nil
 }
 
 func (r *NeedRepository) BrowseNeedsCount(ctx context.Context, f BrowseNeedsFilter) (int, error) {
@@ -180,39 +203,6 @@ func (r *NeedRepository) BrowseNeedsCount(ctx context.Context, f BrowseNeedsFilt
 	return total, nil
 }
 
-func (r *NeedRepository) BrowseDistinctCities(ctx context.Context) ([]string, error) {
-	qb := psql().
-		Select("DISTINCT COALESCE(sa.city, pa.city) AS city").
-		From(browseFromClause).
-		LeftJoin(browseJoinSelectedAddr).
-		LeftJoin(browseJoinPrimaryAddr).
-		Where(sq.Eq{"n.status": []types.NeedStatus{types.NeedStatusActive, types.NeedStatusFunded}}).
-		Where(sq.Eq{"n.deleted_at": nil}).
-		Where("COALESCE(sa.city, pa.city) IS NOT NULL").
-		OrderBy("city")
-
-	query, args, err := qb.ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate browse distinct cities query: %w", err)
-	}
-
-	cities := make([]string, 0)
-	rows, err := r.pool.Query(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch browse distinct cities: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var city string
-		if err := rows.Scan(&city); err != nil {
-			return nil, fmt.Errorf("failed to scan browse city row: %w", err)
-		}
-		cities = append(cities, city)
-	}
-
-	return cities, nil
-}
 
 func (r *NeedRepository) ModerationQueueNeeds(ctx context.Context) ([]*types.Need, error) {
 	return r.ModerationQueueNeedsPage(ctx, 1, 500)

--- a/internal/usps/client.go
+++ b/internal/usps/client.go
@@ -22,9 +22,9 @@ const (
 // Client is a USPS API client that handles OAuth2 token management
 // and address validation.
 type Client struct {
-	httpClient   *http.Client
-	baseURL      string
-	consumerKey  string
+	httpClient     *http.Client
+	baseURL        string
+	consumerKey    string
 	consumerSecret string
 
 	mu          sync.Mutex
@@ -108,12 +108,12 @@ type AddressInput struct {
 
 // StandardizedAddress is the result of a successful address validation.
 type StandardizedAddress struct {
-	StreetAddress string
+	StreetAddress    string
 	SecondaryAddress string
-	City          string
-	State         string
-	ZIPCode       string
-	ZIPPlus4      string
+	City             string
+	State            string
+	ZIPCode          string
+	ZIPPlus4         string
 }
 
 // addressResponse represents the USPS address validation API response.

--- a/migrations/zip_centroids.pg.hcl
+++ b/migrations/zip_centroids.pg.hcl
@@ -17,7 +17,18 @@ table "zip_centroids" {
     null = false
   }
 
+  column "geog" {
+    type    = sql("christjesus.geography(Point, 4326)")
+    null    = true
+    comment = "PostGIS geography point derived from latitude/longitude"
+  }
+
   primary_key {
     columns = [column.zip_code]
+  }
+
+  index "idx_zip_centroids_geog" {
+    columns = [column.geog]
+    type    = GiST
   }
 }

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -51,7 +51,6 @@ type BrowsePageData struct {
 	BasePageData
 	Needs                []*BrowseNeedCard
 	Categories           []*NeedCategory
-	Cities               []string
 	Filters              BrowseFilters
 	LoadResultsOnRender  bool
 	ShowResultsSkeletons bool
@@ -63,15 +62,16 @@ type BrowsePageData struct {
 }
 
 type BrowseFilters struct {
-	Search          string
-	City            string
+	Search      string
+	ZipCode     string
+	Radius      string
 	CategoryIDs map[string]bool
 	Urgency     string
-	FundingMax      int
-	ViewMode        string
-	SortBy          string
-	Page            int
-	PageSize        int
+	FundingMax  int
+	ViewMode    string
+	SortBy      string
+	Page        int
+	PageSize    int
 }
 
 type BrowseNeedCard struct {
@@ -80,6 +80,7 @@ type BrowseNeedCard struct {
 	City              string
 	State             string
 	CityState         string
+	DistanceMiles     *float64
 	UrgencyLabel      string
 	UrgencyDotClass   string
 	PrimaryCategoryID string
@@ -123,9 +124,9 @@ type NeedDetailPageData struct {
 	OwnerName           string
 	SelectedAddress     *UserAddress
 	CityState           string
-	UrgencyLabel    string
-	UrgencyDotClass string
-	FundingPercent  int
+	UrgencyLabel        string
+	UrgencyDotClass     string
+	FundingPercent      int
 	Story               *NeedStory
 	PrimaryCategory     *NeedCategory
 	SecondaryCategories []*NeedCategory
@@ -453,10 +454,10 @@ type AdminNeedExplorerPageData struct {
 }
 
 type AdminNeedStatusCard struct {
-	Status  NeedStatus
-	Label   string
-	Count   int
-	Href    string
+	Status   NeedStatus
+	Label    string
+	Count    int
+	Href     string
 	IsActive bool
 }
 
@@ -566,11 +567,11 @@ type AdminUserDetailPageData struct {
 	BackHref    string
 
 	// Recipient-specific
-	IsRecipient   bool
-	Needs         []*AdminUserNeedItem
-	HasNeeds      bool
-	TotalNeeds    int
-	NeedsSummary  string // e.g. "3 needs, 1 active, $450.00 raised"
+	IsRecipient  bool
+	Needs        []*AdminUserNeedItem
+	HasNeeds     bool
+	TotalNeeds   int
+	NeedsSummary string // e.g. "3 needs, 1 active, $450.00 raised"
 
 	// Donor-specific
 	IsDonor          bool
@@ -581,14 +582,14 @@ type AdminUserDetailPageData struct {
 }
 
 type AdminUserNeedItem struct {
-	NeedID          string
+	NeedID           string
 	ShortDescription string
-	Status          NeedStatus
-	AmountNeeded    string
-	AmountRaised    string
-	FundingPercent  int
-	CreatedAt       string
-	ReviewHref      string
+	Status           NeedStatus
+	AmountNeeded     string
+	AmountRaised     string
+	FundingPercent   int
+	CreatedAt        string
+	ReviewHref       string
 }
 
 type AdminUserDonationItem struct {

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -6,8 +6,8 @@ type UserType string
 
 const (
 	UserTypeRecipient UserType = "recipient"
-	UserTypeDonor   UserType = "donor"
-	UserTypeSponsor UserType = "sponsor"
+	UserTypeDonor     UserType = "donor"
+	UserTypeSponsor   UserType = "sponsor"
 )
 
 type User struct {


### PR DESCRIPTION
## Summary

- Replace city dropdown filter with ZIP code input + radius dropdown (5/15/25/50 mi, Anywhere) on the browse needs page
- Use PostGIS `ST_DWithin` for spatial radius filtering and `ST_Distance` for distance display on need cards
- Add `geography(Point, 4326)` column with GiST index to `zip_centroids` table
- Pre-populate ZIP/radius from donor preferences when logged in
- Seed Charlotte-area addresses for fake users to enable local testing

## Test plan

- [ ] Enable PostGIS extension on `christjesus` schema in Supabase
- [ ] Run `just migrate` to apply geog column + GiST index
- [ ] Run `just import-zips` to populate geography data
- [ ] Run `just seed` to give fake users addresses
- [ ] Verify browse page shows ZIP input + radius dropdown instead of city dropdown
- [ ] Enter ZIP 28202 + 25mi radius — confirm results filtered and distance shown on cards
- [ ] Sort by "Nearest" — confirm distance-ascending order
- [ ] Set radius to "Anywhere" — confirm all results shown with distance displayed
- [ ] Clear ZIP — confirm no distance filtering or display
- [ ] Log in as donor with preferences — confirm ZIP/radius pre-populated

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)