### PR TITLE
feat: add donor preferences page to profile

### DIFF
--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -482,6 +482,7 @@ func buildProfileSidebar(userType string) []types.ProfileNavItem {
 		{Label: "My Needs", Href: "#my-needs", Active: false, Section: "my-needs", ShowItem: userType == string(types.UserTypeRecipient)},
 		{Label: "Need Status", Href: "#need-status", Active: false, Section: "need-status", ShowItem: userType == string(types.UserTypeRecipient)},
 		{Label: "Donation History", Href: "#donations", Active: false, Section: "donations", ShowItem: userType == string(types.UserTypeDonor)},
+		{Label: "My Preferences", Href: RoutePattern(RouteProfileDonorPreferences), Active: false, Section: "my-preferences", ShowItem: userType == string(types.UserTypeDonor)},
 	}
 
 	filtered := make([]types.ProfileNavItem, 0, len(items))

--- a/internal/server/profile_preferences.go
+++ b/internal/server/profile_preferences.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"christjesus/pkg/types"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (s *Service) handleGetProfileDonorPreferences(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userID, err := s.userIDFromContext(ctx)
+	if err != nil {
+		s.logger.WithError(err).Error("user id not found in context")
+		s.internalServerError(w)
+		return
+	}
+
+	categories, err := s.categoryRepo.Categories(ctx)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to load categories for profile donor preferences")
+		s.internalServerError(w)
+		return
+	}
+
+	pref, err := s.donorPreferenceRepo.ByUserID(ctx, userID)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to load donor preferences for profile")
+		s.internalServerError(w)
+		return
+	}
+
+	assignments, err := s.donorPreferenceAssignRepo.AssignmentsByUserID(ctx, userID)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to load donor preference category assignments for profile")
+		s.internalServerError(w)
+		return
+	}
+
+	selectedCategoryIDs := make(map[string]bool)
+	for _, a := range assignments {
+		selectedCategoryIDs[a.CategoryID] = true
+	}
+
+	data := &types.ProfileDonorPreferencesPageData{
+		BasePageData:            types.BasePageData{Title: "My Preferences"},
+		SidebarItems:            buildProfileSidebar(string(types.UserTypeDonor)),
+		Categories:              categories,
+		SelectedCategoryIDs:     selectedCategoryIDs,
+		UpdatePreferencesAction: s.route(RouteProfileDonorPreferences, nil),
+		Notice:                  strings.TrimSpace(r.URL.Query().Get("notice")),
+		Error:                   strings.TrimSpace(r.URL.Query().Get("error")),
+	}
+	if pref != nil {
+		if pref.ZipCode != nil {
+			data.ZipCode = *pref.ZipCode
+		}
+		if pref.Radius != nil {
+			data.Radius = *pref.Radius
+		}
+		if pref.DonationRange != nil {
+			data.DonationRange = *pref.DonationRange
+		}
+		if pref.NotificationFrequency != nil {
+			data.NotificationFrequency = *pref.NotificationFrequency
+		}
+	}
+
+	err = s.renderTemplate(w, r, "page.profile.donor.preferences", data)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to render profile donor preferences page")
+		s.internalServerError(w)
+		return
+	}
+}
+
+func (s *Service) handlePostProfileDonorPreferences(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userID, err := s.userIDFromContext(ctx)
+	if err != nil {
+		s.logger.WithError(err).Error("user id not found in context")
+		s.internalServerError(w)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		s.logger.WithError(err).Error("failed to parse profile donor preferences form")
+		s.internalServerError(w)
+		return
+	}
+
+	cleanOptional := func(value string) *string {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return nil
+		}
+		return &trimmed
+	}
+
+	selectedCategoryIDs := make([]string, 0, len(r.Form["categories"]))
+	seen := make(map[string]bool)
+	for _, categoryID := range r.Form["categories"] {
+		categoryID = strings.TrimSpace(categoryID)
+		if categoryID == "" || seen[categoryID] {
+			continue
+		}
+		selectedCategoryIDs = append(selectedCategoryIDs, categoryID)
+		seen[categoryID] = true
+	}
+
+	if len(selectedCategoryIDs) > 0 {
+		validCategories, err := s.categoryRepo.CategoriesByIDs(ctx, selectedCategoryIDs)
+		if err != nil {
+			s.logger.WithError(err).Error("failed to validate donor preference categories")
+			s.internalServerError(w)
+			return
+		}
+		if len(validCategories) != len(selectedCategoryIDs) {
+			s.logger.WithField("selected_count", len(selectedCategoryIDs)).
+				WithField("valid_count", len(validCategories)).
+				Warn("profile donor preferences contained invalid category ids")
+			s.internalServerError(w)
+			return
+		}
+	}
+
+	existingPref, err := s.donorPreferenceRepo.ByUserID(ctx, userID)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to fetch existing donor preferences for profile update")
+		s.internalServerError(w)
+		return
+	}
+
+	if existingPref == nil {
+		newPref := &types.DonorPreference{
+			UserID:                userID,
+			ZipCode:               cleanOptional(r.FormValue("zipCode")),
+			Radius:                cleanOptional(r.FormValue("radius")),
+			DonationRange:         cleanOptional(r.FormValue("donationRange")),
+			NotificationFrequency: cleanOptional(r.FormValue("notificationFrequency")),
+		}
+		err = s.donorPreferenceRepo.Create(ctx, newPref)
+		if err != nil {
+			s.logger.WithError(err).Error("failed to create donor preferences from profile")
+			s.internalServerError(w)
+			return
+		}
+	} else {
+		existingPref.ZipCode = cleanOptional(r.FormValue("zipCode"))
+		existingPref.Radius = cleanOptional(r.FormValue("radius"))
+		existingPref.DonationRange = cleanOptional(r.FormValue("donationRange"))
+		existingPref.NotificationFrequency = cleanOptional(r.FormValue("notificationFrequency"))
+
+		err = s.donorPreferenceRepo.Update(ctx, userID, existingPref)
+		if err != nil {
+			s.logger.WithError(err).Error("failed to update donor preferences from profile")
+			s.internalServerError(w)
+			return
+		}
+	}
+
+	err = s.donorPreferenceAssignRepo.ReplaceAssignments(ctx, userID, selectedCategoryIDs)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to replace donor preference category assignments from profile")
+		s.internalServerError(w)
+		return
+	}
+
+	v := url.Values{}
+	v.Set("notice", "Preferences saved.")
+	http.Redirect(w, r, s.routeWithQuery(RouteProfileDonorPreferences, nil, v), http.StatusSeeOther)
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -45,7 +45,8 @@ const (
 	RouteProfileNeedEditDelete     RouteName = "profile.need.edit.documents.delete"
 	RouteProfileNeedEditReview     RouteName = "profile.need.edit.review"
 	RouteProfileDonationReceipt    RouteName = "profile.donation.receipt"
-	RouteProfileUpdateName         RouteName = "profile.update.name"
+	RouteProfileUpdateName             RouteName = "profile.update.name"
+	RouteProfileDonorPreferences       RouteName = "profile.donor.preferences"
 
 	RouteOnboarding              RouteName = "onboarding"
 	RouteOnboardingAboutYou      RouteName = "onboarding.about.you"
@@ -122,6 +123,7 @@ var routePatterns = map[RouteName]string{
 	RouteProfileNeedEditReview:         "/profile/needs/:needID/edit/review",
 	RouteProfileDonationReceipt:        "/profile/donations/:intentID/receipt",
 	RouteProfileUpdateName:             "/profile/update/name",
+	RouteProfileDonorPreferences:       "/profile/preferences",
 	RouteOnboarding:                    "/onboarding",
 	RouteOnboardingAboutYou:            "/onboarding/about-you",
 	RouteOnboardingHowWeServeYou:       "/onboarding/how-we-serve-you",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -219,6 +219,8 @@ func (s *Service) buildRouter(r *flow.Mux, csrfKey []byte) {
 			r.HandleFunc(RoutePattern(RouteProfileNeedEditReview), s.handlePostProfileNeedEditReview, http.MethodPost)
 			r.HandleFunc(RoutePattern(RouteProfileDonationReceipt), s.handleGetProfileDonationReceipt, http.MethodGet)
 			r.HandleFunc(RoutePattern(RouteProfileUpdateName), s.handlePostProfileUpdateName, http.MethodPost)
+			r.HandleFunc(RoutePattern(RouteProfileDonorPreferences), s.handleGetProfileDonorPreferences, http.MethodGet)
+			r.HandleFunc(RoutePattern(RouteProfileDonorPreferences), s.handlePostProfileDonorPreferences, http.MethodPost)
 
 			r.HandleFunc(RoutePattern(RouteOnboarding), s.handleGetOnboarding, http.MethodGet)
 			// r.HandleFunc(RoutePattern(RouteOnboarding), s.handlePostOnboarding, http.MethodPost)

--- a/internal/server/templates/pages/profile-donor-preferences.html
+++ b/internal/server/templates/pages/profile-donor-preferences.html
@@ -1,0 +1,111 @@
+{{define "page.profile.donor.preferences"}}
+{{template "header" .}}
+
+<div class="mx-auto w-full max-w-6xl px-4 py-10 md:px-6">
+  <div class="mb-8">
+    <h1 class="text-3xl font-semibold text-foreground">Profile</h1>
+    <p class="text-muted-foreground">Manage your donor preferences.</p>
+  </div>
+
+  <div class="grid gap-6 md:grid-cols-[260px_1fr]">
+    <aside class="rounded-xl border bg-background p-4">
+      <p class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Account</p>
+      <nav class="space-y-1">
+        {{range .SidebarItems}}
+        <a href="{{.Href}}" class="block rounded-md px-3 py-2 text-sm text-foreground transition-colors hover:bg-muted">
+          {{.Label}}
+        </a>
+        {{end}}
+      </nav>
+    </aside>
+
+    <section class="space-y-6">
+      {{if .Notice}}
+      <div class="rounded-md border border-[color:var(--cj-accent)]/30 bg-[color:var(--cj-accent)]/10 px-4 py-3 text-sm text-foreground">
+        {{.Notice}}
+      </div>
+      {{end}}
+
+      {{if .Error}}
+      <div class="rounded-md border border-[color:var(--cj-error)] border-l-4 bg-muted px-4 py-3 text-sm font-semibold text-[color:var(--cj-error)]" role="alert">
+        {{.Error}}
+      </div>
+      {{end}}
+
+      <div class="rounded-xl border bg-background p-6">
+        <h2 class="text-xl font-semibold text-foreground">My Preferences</h2>
+        <p class="mt-1 text-sm text-muted-foreground">These preferences pre-fill filters on the browse page so you see relevant needs right away.</p>
+
+        <form id="donor-preferences-form" action="{{.UpdatePreferencesAction}}" method="post" class="mt-6 space-y-6">
+          {{.CSRFField}}
+
+          <div class="grid gap-4 md:grid-cols-2">
+            <div class="space-y-1">
+              <label for="pref-zip" class="block text-sm font-medium text-foreground">ZIP Code</label>
+              <input id="pref-zip" type="text" name="zipCode" placeholder="e.g. 90210" value="{{.ZipCode}}" maxlength="5" inputmode="numeric"
+                class="block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[color:var(--cj-primary)]" />
+            </div>
+            <div class="space-y-1">
+              <label for="pref-radius" class="block text-sm font-medium text-foreground">Radius</label>
+              <select id="pref-radius" name="radius"
+                class="block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[color:var(--cj-primary)]">
+                <option value="" {{if eq .Radius ""}}selected{{end}}>Select a radius</option>
+                <option value="5-miles" {{if eq .Radius "5-miles"}}selected{{end}}>5 miles</option>
+                <option value="15-miles" {{if eq .Radius "15-miles"}}selected{{end}}>15 miles</option>
+                <option value="25-miles" {{if eq .Radius "25-miles"}}selected{{end}}>25 miles</option>
+                <option value="anywhere" {{if eq .Radius "anywhere"}}selected{{end}}>Anywhere</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <p class="text-sm font-medium text-foreground">Categories you care about</p>
+            <div class="flex flex-wrap gap-2">
+              {{range .Categories}}
+              <label class="inline-flex cursor-pointer items-center gap-2 rounded-full border border-border px-3 py-1.5 text-sm text-muted-foreground transition hover:bg-muted">
+                <input type="checkbox" name="categories" value="{{.ID}}" class="h-3.5 w-3.5 rounded border-border" {{if index $.SelectedCategoryIDs .ID}}checked{{end}} />
+                {{.Name}}
+              </label>
+              {{end}}
+            </div>
+          </div>
+
+          <div class="grid gap-4 md:grid-cols-2">
+            <div class="space-y-1">
+              <label for="pref-donation-range" class="block text-sm font-medium text-foreground">Donation Range</label>
+              <select id="pref-donation-range" name="donationRange"
+                class="block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[color:var(--cj-primary)]">
+                <option value="" {{if eq .DonationRange ""}}selected{{end}}>Select a range</option>
+                <option value="under-50" {{if eq .DonationRange "under-50"}}selected{{end}}>Under $50</option>
+                <option value="50-100" {{if eq .DonationRange "50-100"}}selected{{end}}>$50 – $100</option>
+                <option value="100-500" {{if eq .DonationRange "100-500"}}selected{{end}}>$100 – $500</option>
+                <option value="500-plus" {{if eq .DonationRange "500-plus"}}selected{{end}}>$500+</option>
+              </select>
+            </div>
+            <div class="space-y-1">
+              <label for="pref-notification" class="block text-sm font-medium text-foreground">Email Notifications</label>
+              <select id="pref-notification" name="notificationFrequency"
+                class="block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[color:var(--cj-primary)]">
+                <option value="" {{if eq .NotificationFrequency ""}}selected{{end}}>Select frequency</option>
+                <option value="daily" {{if eq .NotificationFrequency "daily"}}selected{{end}}>Daily</option>
+                <option value="weekly" {{if eq .NotificationFrequency "weekly"}}selected{{end}}>Weekly</option>
+                <option value="monthly" {{if eq .NotificationFrequency "monthly"}}selected{{end}}>Monthly</option>
+                <option value="never" {{if eq .NotificationFrequency "never"}}selected{{end}}>Never</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="flex items-center justify-end">
+            <button type="submit"
+              class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
+              Save Preferences
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
+</div>
+
+{{template "footer" .}}
+{{end}}

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -346,6 +346,20 @@ type ProfilePageData struct {
 	HasDonations      bool
 }
 
+type ProfileDonorPreferencesPageData struct {
+	BasePageData
+	SidebarItems           []ProfileNavItem
+	Notice                 string
+	Error                  string
+	Categories             []*NeedCategory
+	ZipCode                string
+	Radius                 string
+	DonationRange          string
+	NotificationFrequency  string
+	SelectedCategoryIDs    map[string]bool
+	UpdatePreferencesAction string
+}
+
 type ProfileNeedSummary struct {
 	NeedID              string
 	PrimaryCategoryName string


### PR DESCRIPTION
## Summary

- Adds `GET /profile/preferences` and `POST /profile/preferences` as a dedicated page within the profile section
- Donors can view and edit their saved preferences (ZIP/radius, categories, donation range, notification frequency) without going through onboarding again
- "My Preferences" sidebar link is shown for donors only
- Redirects back to the preferences page with a success notice on save

## Related

Closes #47 (partial — this is the profile editing half; browse pre-filtering is a follow-on)

## Test plan

- [x] Log in as a donor and navigate to `/profile/preferences` — form should be pre-populated with any saved preferences
- [x] Update preferences and save — should redirect back with "Preferences saved." notice and reflect updated values
- [x] Verify "My Preferences" appears in the profile sidebar for donors but not for recipients
- [x] Submit with no categories selected — should save successfully (categories are optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)