### PR TITLE
feat: apply donor preferences as default filters on browse page

### DIFF
--- a/internal/server/pages.go
+++ b/internal/server/pages.go
@@ -338,19 +338,44 @@ func (s *Service) handleBrowse(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	filters := parseBrowseFilters(r.URL.Query())
 
-	// Pre-populate ZIP/radius from donor preferences if logged in and no query params set
-	if filters.ZipCode == "" {
+	prefsApplied := false
+	hasDonorPrefs := false
+
+	// Only apply preference defaults on full page loads, not HTMX filter submissions.
+	// HTMX requests represent explicit user filter interactions — trust them as-is.
+	if !isHXRequest(r) {
 		if session, ok := sessionFromContext(ctx); ok && session.UserID != "" {
 			pref, err := s.donorPreferenceRepo.ByUserID(ctx, session.UserID)
 			if err != nil {
 				s.logger.WithError(err).Warn("failed to fetch donor preferences for browse pre-population")
 			}
 			if pref != nil {
-				if pref.ZipCode != nil && *pref.ZipCode != "" {
-					filters.ZipCode = *pref.ZipCode
+				hasDonorPrefs = true
+				if filters.UsePrefs != "0" {
+					if filters.ZipCode == "" && pref.ZipCode != nil && *pref.ZipCode != "" {
+						filters.ZipCode = *pref.ZipCode
+						prefsApplied = true
+					}
+					if filters.Radius == "" && pref.Radius != nil && *pref.Radius != "" {
+						if normalized := normalizeBrowseRadius(*pref.Radius); normalized != "" {
+							filters.Radius = normalized
+							prefsApplied = true
+						}
+					}
 				}
-				if pref.Radius != nil && *pref.Radius != "" {
-					filters.Radius = normalizeBrowseRadius(*pref.Radius)
+			}
+
+			if filters.UsePrefs != "0" && len(filters.CategoryIDs) == 0 {
+				assignments, err := s.donorPreferenceAssignRepo.AssignmentsByUserID(ctx, session.UserID)
+				if err != nil {
+					s.logger.WithError(err).Warn("failed to fetch donor preference categories for browse pre-population")
+				} else if len(assignments) > 0 {
+					hasDonorPrefs = true
+					filters.CategoryIDs = make(map[string]bool, len(assignments))
+					for _, a := range assignments {
+						filters.CategoryIDs[a.CategoryID] = true
+					}
+					prefsApplied = true
 				}
 			}
 		}
@@ -390,6 +415,8 @@ func (s *Service) handleBrowse(w http.ResponseWriter, r *http.Request) {
 		Filters:              filters,
 		LoadResultsOnRender:  true,
 		ShowResultsSkeletons: true,
+		PrefsApplied:         prefsApplied,
+		HasDonorPrefs:        hasDonorPrefs,
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -422,6 +449,11 @@ func parseBrowseFilters(query url.Values) types.BrowseFilters {
 		}
 	}
 
+	usePrefs := ""
+	if strings.TrimSpace(query.Get("use_prefs")) == "0" {
+		usePrefs = "0"
+	}
+
 	return types.BrowseFilters{
 		Search:      strings.TrimSpace(query.Get("search")),
 		ZipCode:     normalizeBrowseZipCode(query.Get("zip")),
@@ -433,6 +465,7 @@ func parseBrowseFilters(query url.Values) types.BrowseFilters {
 		SortBy:      normalizeBrowseSortBy(query.Get("sort")),
 		Page:        parsePositiveInt(query.Get("page"), 1),
 		PageSize:    browseDefaultPageSize,
+		UsePrefs:    usePrefs,
 	}
 }
 
@@ -606,6 +639,9 @@ func (s *Service) buildBrowsePageHref(filters types.BrowseFilters, page int) str
 	}
 	if filters.SortBy != "urgency" {
 		v.Set("sort", filters.SortBy)
+	}
+	if filters.UsePrefs == "0" {
+		v.Set("use_prefs", "0")
 	}
 	return s.routeWithQuery(RouteBrowse, nil, v)
 }

--- a/internal/server/templates/components/filters-panel.html
+++ b/internal/server/templates/components/filters-panel.html
@@ -3,6 +3,25 @@
   hx-push-url="true" hx-indicator="#browse-loading" class="space-y-6 rounded-xl border border-border bg-white p-4 shadow-sm">
   <input type="hidden" id="browse-view-input" name="view" value="{{.Filters.ViewMode}}" />
   <input type="hidden" id="browse-sort-input" name="sort" value="{{.Filters.SortBy}}" />
+  <input type="hidden" name="use_prefs" value="{{.Filters.UsePrefs}}" />
+
+  {{if .PrefsApplied}}
+  <div class="flex items-center justify-between">
+    <span class="text-xs text-muted-foreground">Using your preferences</span>
+    <a href="{{route "browse" nil}}?use_prefs=0"
+      class="inline-flex h-7 items-center justify-center rounded-md border border-border px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted">
+      Disable
+    </a>
+  </div>
+  {{else if .HasDonorPrefs}}
+  <div class="flex items-center justify-between">
+    <span class="text-xs text-muted-foreground">Preferences off</span>
+    <a href="{{route "browse" nil}}"
+      class="inline-flex h-7 items-center justify-center rounded-md border border-border px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted">
+      Enable
+    </a>
+  </div>
+  {{end}}
 
   <!--
   <div>

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -59,6 +59,8 @@ type BrowsePageData struct {
 	TotalPages           int
 	PrevHref             string
 	NextHref             string
+	PrefsApplied         bool
+	HasDonorPrefs        bool
 }
 
 type BrowseFilters struct {
@@ -72,6 +74,7 @@ type BrowseFilters struct {
 	SortBy      string
 	Page        int
 	PageSize    int
+	UsePrefs    string
 }
 
 type BrowseNeedCard struct {


### PR DESCRIPTION
## Summary

- Pre-populates ZIP, radius, and categories from saved donor preferences on the initial browse page load
- HTMX filter submissions bypass pref injection — explicit user filter actions are always respected, keeping the filter panel and results in sync
- Adds a toggle at the top of the filters panel: "Using your preferences — Disable" / "Preferences off — Enable"
- `use_prefs=0` query param disables preferences and persists through filter form submissions and pagination

## Test plan

- [x] Log in as a donor with saved preferences and visit `/browse` — ZIP, radius, and categories should be pre-filled
- [x] Uncheck a preference category and apply filters — results and filter panel should both reflect the unchecked state
- [x] Click "Disable" in the filters panel — all preference defaults should be cleared
- [x] Click "Enable" — preferences should be re-applied
- [x] Verify non-donors and unauthenticated users see no toggle and unfiltered results

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)