### PR TITLE
feat: profile edit controls

### DIFF
--- a/internal/const.go
+++ b/internal/const.go
@@ -10,6 +10,7 @@ const (
 )
 
 const (
-	AuthAdminClaim string = "https://christjesus.app/claims/roles"
-	AuthAdminValue string = "admin"
+	AuthAdminClaim       string = "https://christjesus.app/claims/roles"
+	AuthAdminValue       string = "admin"
+	AuthDisplayNameClaim string = "https://christjesus.app/claims/display_name"
 )

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -48,6 +48,7 @@ type authUserState struct {
 	Email       string
 	GivenName   string
 	FamilyName  string
+	DisplayName string
 	UserType    string
 	IsAdmin     bool
 }
@@ -58,12 +59,13 @@ type responseWriter struct {
 }
 
 type AuthClaims struct {
-	Subject    string
-	Email      string
-	GivenName  string
-	FamilyName string
-	Nonce      string
-	IsAdmin    bool
+	Subject     string
+	Email       string
+	GivenName   string
+	FamilyName  string
+	DisplayName string
+	Nonce       string
+	IsAdmin     bool
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
@@ -149,7 +151,13 @@ func (s *Service) AttachAuthContext(next http.Handler) http.Handler {
 		if familyName == "" {
 			familyName = strings.TrimSpace(claims.FamilyName)
 		}
-		displayName := strings.TrimSpace(givenName)
+		displayName := strings.TrimSpace(state.DisplayName)
+		if displayName == "" {
+			displayName = strings.TrimSpace(claims.DisplayName)
+		}
+		if displayName == "" {
+			displayName = strings.TrimSpace(givenName)
+		}
 		if displayName == "" {
 			displayName = "Friend"
 		}
@@ -255,6 +263,12 @@ func (s *Service) authClaimsFromToken(ctx context.Context, tokenString string) (
 	}
 	familyName = strings.TrimSpace(familyName)
 
+	var displayName string
+	if err := token.Get(internal.AuthDisplayNameClaim, &displayName); err != nil {
+		displayName = ""
+	}
+	displayName = strings.TrimSpace(displayName)
+
 	var nonce string
 	if err := token.Get("nonce", &nonce); err != nil {
 		nonce = ""
@@ -276,12 +290,13 @@ func (s *Service) authClaimsFromToken(ctx context.Context, tokenString string) (
 	}
 
 	return &AuthClaims{
-		Subject:    subject,
-		Email:      email,
-		GivenName:  givenName,
-		FamilyName: familyName,
-		Nonce:      nonce,
-		IsAdmin:    isAdmin,
+		Subject:     subject,
+		Email:       email,
+		GivenName:   givenName,
+		FamilyName:  familyName,
+		DisplayName: displayName,
+		Nonce:       nonce,
+		IsAdmin:     isAdmin,
 	}, nil
 }
 

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -202,21 +202,25 @@ func (s *Service) handleGetProfile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := &types.ProfilePageData{
-		BasePageData:      types.BasePageData{Title: "My Profile"},
-		UserID:            session.UserID,
-		UserEmail:         session.Email,
-		WelcomeName:       session.DisplayName,
-		DisplayName:       session.DisplayName,
-		UserType:          userType,
-		Notice:            strings.TrimSpace(r.URL.Query().Get("notice")),
-		Error:             strings.TrimSpace(r.URL.Query().Get("error")),
-		UpdateNameAction:  s.route(RouteProfileUpdateName, nil),
-		SidebarItems:      buildProfileSidebar(userType),
-		Needs:             myNeeds,
-		NeedSummaries:     needSummaries,
-		DonationSummaries: donationSummaries,
-		HasNeeds:          len(myNeeds) > 0,
-		HasDonations:      len(donationSummaries) > 0,
+		BasePageData:            types.BasePageData{Title: "My Profile"},
+		UserID:                  session.UserID,
+		UserEmail:               session.Email,
+		WelcomeName:             session.DisplayName,
+		DisplayName:             session.DisplayName,
+		UserType:                userType,
+		Notice:                  strings.TrimSpace(r.URL.Query().Get("notice")),
+		Error:                   strings.TrimSpace(r.URL.Query().Get("error")),
+		EditMode:                r.URL.Query().Get("edit") == "1",
+		UpdateNameAction:        s.route(RouteProfileUpdateName, nil),
+		UpdateEmailAction:       s.route(RouteProfileUpdateEmail, nil),
+		SendPasswordResetAction: s.route(RouteProfileSendPasswordReset, nil),
+		IsDatabaseUser:          strings.HasPrefix(session.AuthSubject, "auth0|"),
+		SidebarItems:            buildProfileSidebar(userType),
+		Needs:                   myNeeds,
+		NeedSummaries:           needSummaries,
+		DonationSummaries:       donationSummaries,
+		HasNeeds:                len(myNeeds) > 0,
+		HasDonations:            len(donationSummaries) > 0,
 	}
 
 	err = s.renderTemplate(w, r, "page.profile", data)
@@ -314,6 +318,15 @@ func (s *Service) redirectProfileWithError(w http.ResponseWriter, r *http.Reques
 	http.Redirect(w, r, s.routeWithQuery(RouteProfile, nil, v), http.StatusSeeOther)
 }
 
+// redirectProfileEditWithError redirects to the profile page with an error and
+// edit=1 so the edit section auto-opens, keeping the user in context.
+func (s *Service) redirectProfileEditWithError(w http.ResponseWriter, r *http.Request, msg string) {
+	v := url.Values{}
+	v.Set("error", msg)
+	v.Set("edit", "1")
+	http.Redirect(w, r, s.routeWithQuery(RouteProfile, nil, v), http.StatusSeeOther)
+}
+
 func formatUSDFromCents(cents int) string {
 	dollars := float64(cents) / 100.0
 	return fmt.Sprintf("$%.2f", dollars)
@@ -359,17 +372,17 @@ func (s *Service) handlePostProfileUpdateName(w http.ResponseWriter, r *http.Req
 	ctx := r.Context()
 
 	if err := r.ParseForm(); err != nil {
-		s.redirectProfileWithError(w, r, "Invalid form submission.")
+		s.redirectProfileEditWithError(w, r, "Invalid form submission.")
 		return
 	}
 
 	displayName := strings.TrimSpace(r.FormValue("display_name"))
 	if displayName == "" {
-		s.redirectProfileWithError(w, r, "Display name cannot be empty.")
+		s.redirectProfileEditWithError(w, r, "Display name cannot be empty.")
 		return
 	}
 	if len([]rune(displayName)) > 100 {
-		s.redirectProfileWithError(w, r, "Display name must be 100 characters or fewer.")
+		s.redirectProfileEditWithError(w, r, "Display name must be 100 characters or fewer.")
 		return
 	}
 
@@ -381,20 +394,94 @@ func (s *Service) handlePostProfileUpdateName(w http.ResponseWriter, r *http.Req
 
 	authSubject := strings.TrimSpace(state.AuthSubject)
 	if authSubject == "" {
-		s.redirectProfileWithError(w, r, "Unable to update profile: missing identity.")
+		s.redirectProfileEditWithError(w, r, "Unable to update profile: missing identity.")
 		return
 	}
 
 	if err := s.auth0UpdateUserDisplayName(ctx, authSubject, displayName); err != nil {
 		s.logger.WithError(err).WithField("auth_subject", authSubject).Error("failed to update Auth0 user display name")
-		s.redirectProfileWithError(w, r, "Unable to update profile. Please try again later.")
+		s.redirectProfileEditWithError(w, r, "Unable to update display name. Please try again later.")
 		return
 	}
 
-	// state.DisplayName = displayName
+	state.DisplayName = displayName
 	s.setAuthUserStateCookie(w, state, s.config.SessionMaxAgeSec)
 
 	s.redirectProfileWithNotice(w, r, "Display name updated.")
+}
+
+func (s *Service) handlePostProfileUpdateEmail(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		s.redirectProfileEditWithError(w, r, "Invalid form submission.")
+		return
+	}
+
+	email := strings.TrimSpace(r.FormValue("email"))
+	if email == "" {
+		s.redirectProfileEditWithError(w, r, "Email cannot be empty.")
+		return
+	}
+	if !strings.Contains(email, "@") {
+		s.redirectProfileEditWithError(w, r, "Please enter a valid email address.")
+		return
+	}
+
+	state, ok := s.authUserStateFromRequest(r)
+	if !ok {
+		http.Redirect(w, r, s.route(RouteLogin, nil), http.StatusSeeOther)
+		return
+	}
+
+	authSubject := strings.TrimSpace(state.AuthSubject)
+	if authSubject == "" {
+		s.redirectProfileEditWithError(w, r, "Unable to update profile: missing identity.")
+		return
+	}
+
+	if err := s.auth0PatchUser(ctx, authSubject, map[string]any{
+		"email":          email,
+		"email_verified": false,
+	}); err != nil {
+		s.logger.WithError(err).WithField("auth_subject", authSubject).Error("failed to update Auth0 user email")
+		s.redirectProfileEditWithError(w, r, "Unable to update email. Please try again later.")
+		return
+	}
+
+	state.Email = email
+	s.setAuthUserStateCookie(w, state, s.config.SessionMaxAgeSec)
+
+	s.redirectProfileWithNotice(w, r, "Email updated. Check your inbox to verify the new address.")
+}
+
+func (s *Service) handlePostProfileSendPasswordReset(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	state, ok := s.authUserStateFromRequest(r)
+	if !ok {
+		http.Redirect(w, r, s.route(RouteLogin, nil), http.StatusSeeOther)
+		return
+	}
+
+	authSubject := strings.TrimSpace(state.AuthSubject)
+	if authSubject == "" {
+		s.redirectProfileEditWithError(w, r, "Unable to send reset email: missing identity.")
+		return
+	}
+
+	if !strings.HasPrefix(authSubject, "auth0|") {
+		s.redirectProfileEditWithError(w, r, "Password reset is not available for social login accounts.")
+		return
+	}
+
+	if err := s.auth0SendPasswordResetTicket(ctx, authSubject); err != nil {
+		s.logger.WithError(err).WithField("auth_subject", authSubject).Error("failed to send Auth0 password reset ticket")
+		s.redirectProfileEditWithError(w, r, "Unable to send password reset email. Please try again later.")
+		return
+	}
+
+	s.redirectProfileWithNotice(w, r, "Password reset email sent. Check your inbox.")
 }
 
 func (s *Service) auth0ManagementToken(ctx context.Context) (string, error) {
@@ -475,10 +562,49 @@ func (s *Service) auth0PatchUser(ctx context.Context, authSubject string, body m
 	return nil
 }
 
+func (s *Service) auth0SendPasswordResetTicket(ctx context.Context, authSubject string) error {
+	token, err := s.auth0ManagementToken(ctx)
+	if err != nil {
+		return fmt.Errorf("get management token: %w", err)
+	}
+
+	resultURL := s.absoluteRoute(RouteProfile, nil, nil)
+
+	payload := map[string]any{
+		"user_id":    authSubject,
+		"result_url": resultURL,
+		"ttl_sec":    3600,
+	}
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal ticket request: %w", err)
+	}
+
+	ticketURL := strings.TrimRight(s.auth0DomainURL(), "/") + "/api/v2/tickets/password-change"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ticketURL, strings.NewReader(string(encoded)))
+	if err != nil {
+		return fmt.Errorf("create ticket request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("authorization", "Bearer "+token)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute ticket request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("password reset ticket request failed with status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
 func buildProfileSidebar(userType string) []types.ProfileNavItem {
 	items := []types.ProfileNavItem{
 		{Label: "Profile Overview", Href: "#overview", Active: true, Section: "overview", ShowItem: true},
-		{Label: "Edit Profile", Href: "#edit-profile", Active: false, Section: "edit-profile", ShowItem: true},
 		{Label: "My Needs", Href: "#my-needs", Active: false, Section: "my-needs", ShowItem: userType == string(types.UserTypeRecipient)},
 		{Label: "Need Status", Href: "#need-status", Active: false, Section: "need-status", ShowItem: userType == string(types.UserTypeRecipient)},
 		{Label: "Donation History", Href: "#donations", Active: false, Section: "donations", ShowItem: userType == string(types.UserTypeDonor)},
@@ -487,9 +613,10 @@ func buildProfileSidebar(userType string) []types.ProfileNavItem {
 
 	filtered := make([]types.ProfileNavItem, 0, len(items))
 	for _, item := range items {
-		if item.ShowItem {
-			filtered = append(filtered, item)
+		if !item.ShowItem {
+			continue
 		}
+		filtered = append(filtered, item)
 	}
 
 	return filtered

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -46,6 +46,8 @@ const (
 	RouteProfileNeedEditReview     RouteName = "profile.need.edit.review"
 	RouteProfileDonationReceipt    RouteName = "profile.donation.receipt"
 	RouteProfileUpdateName             RouteName = "profile.update.name"
+	RouteProfileUpdateEmail            RouteName = "profile.update.email"
+	RouteProfileSendPasswordReset      RouteName = "profile.send.password.reset"
 	RouteProfileDonorPreferences       RouteName = "profile.donor.preferences"
 
 	RouteOnboarding              RouteName = "onboarding"
@@ -123,6 +125,8 @@ var routePatterns = map[RouteName]string{
 	RouteProfileNeedEditReview:         "/profile/needs/:needID/edit/review",
 	RouteProfileDonationReceipt:        "/profile/donations/:intentID/receipt",
 	RouteProfileUpdateName:             "/profile/update/name",
+	RouteProfileUpdateEmail:            "/profile/update/email",
+	RouteProfileSendPasswordReset:      "/profile/send-password-reset",
 	RouteProfileDonorPreferences:       "/profile/preferences",
 	RouteOnboarding:                    "/onboarding",
 	RouteOnboardingAboutYou:            "/onboarding/about-you",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -219,6 +219,8 @@ func (s *Service) buildRouter(r *flow.Mux, csrfKey []byte) {
 			r.HandleFunc(RoutePattern(RouteProfileNeedEditReview), s.handlePostProfileNeedEditReview, http.MethodPost)
 			r.HandleFunc(RoutePattern(RouteProfileDonationReceipt), s.handleGetProfileDonationReceipt, http.MethodGet)
 			r.HandleFunc(RoutePattern(RouteProfileUpdateName), s.handlePostProfileUpdateName, http.MethodPost)
+			r.HandleFunc(RoutePattern(RouteProfileUpdateEmail), s.handlePostProfileUpdateEmail, http.MethodPost)
+			r.HandleFunc(RoutePattern(RouteProfileSendPasswordReset), s.handlePostProfileSendPasswordReset, http.MethodPost)
 			r.HandleFunc(RoutePattern(RouteProfileDonorPreferences), s.handleGetProfileDonorPreferences, http.MethodGet)
 			r.HandleFunc(RoutePattern(RouteProfileDonorPreferences), s.handlePostProfileDonorPreferences, http.MethodPost)
 

--- a/internal/server/templates/pages/profile.html
+++ b/internal/server/templates/pages/profile.html
@@ -33,7 +33,13 @@
 
     <section class="space-y-6">
       <div id="overview" class="rounded-xl border bg-background p-6">
-        <h2 class="text-xl font-semibold text-foreground">Profile Overview</h2>
+        <div class="flex items-start justify-between">
+          <h2 class="text-xl font-semibold text-foreground">Profile Overview</h2>
+          <button id="edit-profile-toggle" type="button" onclick="toggleProfileEdit()"
+            class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted">
+            Edit
+          </button>
+        </div>
         <dl class="mt-4 grid gap-4 sm:grid-cols-2">
           <div>
             <dt class="text-sm text-muted-foreground">Welcome</dt>
@@ -46,22 +52,81 @@
         </dl>
       </div>
 
-      <div id="edit-profile" class="rounded-xl border bg-background p-6">
+      <div id="edit-profile" class="rounded-xl border bg-background p-6 hidden">
         <h2 class="text-xl font-semibold text-foreground">Edit Profile</h2>
-        <p class="mt-1 text-sm text-muted-foreground">Update how your name appears throughout the site.</p>
-        <form method="POST" action="{{.UpdateNameAction}}" class="mt-4 max-w-sm space-y-4">
-          {{.CSRFField}}
-          <div class="space-y-1">
-            <label for="display_name" class="block text-sm font-medium text-foreground">Display Name</label>
-            <input id="display_name" name="display_name" type="text" value="{{.DisplayName}}" maxlength="100" required
-              class="block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[color:var(--cj-primary)]" />
+        <p class="mt-1 text-sm text-muted-foreground">Manage your account details and security settings.</p>
+
+        <div class="mt-6 space-y-6">
+
+          <!-- Display Name -->
+          <div class="border-t pt-6">
+            <h3 class="text-sm font-semibold text-foreground">Display Name</h3>
+            <p class="mt-1 text-xs text-muted-foreground">This is how your name appears throughout the site.</p>
+            <form method="POST" action="{{.UpdateNameAction}}" class="mt-3 max-w-sm space-y-3">
+              {{.CSRFField}}
+              <input id="display_name" name="display_name" type="text" value="{{.DisplayName}}" maxlength="100" required
+                class="block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[color:var(--cj-primary)]" />
+              <button type="submit"
+                class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
+                Save Display Name
+              </button>
+            </form>
           </div>
-          <button type="submit"
-            class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
-            Save
-          </button>
-        </form>
+
+          <!-- Email Address -->
+          <div class="border-t pt-6">
+            <h3 class="text-sm font-semibold text-foreground">Email Address</h3>
+            <p class="mt-1 text-xs text-muted-foreground">Changing your email will require re-verification.</p>
+            <form method="POST" action="{{.UpdateEmailAction}}" class="mt-3 max-w-sm space-y-3">
+              {{.CSRFField}}
+              <input id="email" name="email" type="email" value="{{.UserEmail}}" required
+                class="block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[color:var(--cj-primary)]" />
+              <button type="submit"
+                class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
+                Save Email
+              </button>
+            </form>
+          </div>
+
+          <!-- Password Reset (database connection users only) -->
+          {{if .IsDatabaseUser}}
+          <div class="border-t pt-6">
+            <h3 class="text-sm font-semibold text-foreground">Password</h3>
+            <p class="mt-1 text-xs text-muted-foreground">We'll send a password reset link to your email address on file.</p>
+            <form method="POST" action="{{.SendPasswordResetAction}}" class="mt-3">
+              {{.CSRFField}}
+              <button type="submit"
+                class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted">
+                Send Password Reset Email
+              </button>
+            </form>
+          </div>
+          {{end}}
+
+          <!-- Cancel -->
+          <div class="border-t pt-6">
+            <button type="button" onclick="toggleProfileEdit()" class="text-sm text-muted-foreground underline hover:text-foreground">
+              Cancel
+            </button>
+          </div>
+        </div>
       </div>
+
+      <script>
+        function toggleProfileEdit() {
+          var card = document.getElementById('edit-profile');
+          var toggle = document.getElementById('edit-profile-toggle');
+          var isEditing = !card.classList.contains('hidden');
+          if (isEditing) {
+            card.classList.add('hidden');
+            toggle.textContent = 'Edit';
+          } else {
+            card.classList.remove('hidden');
+            toggle.textContent = 'Cancel';
+          }
+        }
+        {{if .EditMode}}toggleProfileEdit();{{end}}
+      </script>
 
       {{if eq .UserType "recipient"}}
       <div id="my-needs" class="rounded-xl border bg-background p-6">

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -333,20 +333,24 @@ type ProfileNavItem struct {
 
 type ProfilePageData struct {
 	BasePageData
-	UserID            string
-	UserEmail         string
-	WelcomeName       string
-	DisplayName       string
-	UserType          string
-	Notice            string
-	Error             string
-	UpdateNameAction  string
-	SidebarItems      []ProfileNavItem
-	Needs             []*Need
-	NeedSummaries     []ProfileNeedSummary
-	DonationSummaries []ProfileDonationSummary
-	HasNeeds          bool
-	HasDonations      bool
+	UserID                  string
+	UserEmail               string
+	WelcomeName             string
+	DisplayName             string
+	UserType                string
+	Notice                  string
+	Error                   string
+	EditMode                bool
+	UpdateNameAction        string
+	UpdateEmailAction       string
+	SendPasswordResetAction string
+	IsDatabaseUser          bool
+	SidebarItems            []ProfileNavItem
+	Needs                   []*Need
+	NeedSummaries           []ProfileNeedSummary
+	DonationSummaries       []ProfileDonationSummary
+	HasNeeds                bool
+	HasDonations            bool
 }
 
 type ProfileDonorPreferencesPageData struct {

--- a/terraform/auth0.tf
+++ b/terraform/auth0.tf
@@ -66,7 +66,7 @@ resource "auth0_client_credentials" "mgmt" {
 resource "auth0_client_grant" "mgmt_users" {
   client_id = auth0_client.mgmt.id
   audience  = "https://${data.auth0_tenant.current.domain}/api/v2/"
-  scopes    = ["update:users"]
+  scopes    = ["update:users", "create:user_tickets"]
 }
 
 


### PR DESCRIPTION
## Summary
- Fixes issue #57 — display name updates were silently no-oping because `DisplayName` was never stored in the session cookie and the custom Auth0 claim wasn't being read from the JWT
- Edit forms are now hidden behind an **Edit** button in the Profile Overview card instead of always rendering
- Adds email address update and password reset (Auth0 ticket flow, database-connection users only)
- Adds `create:user_tickets` scope to the Terraform M2M client grant

## Test plan
- [x] Update display name — verify it persists after page reload without re-login
- [x] Update email — verify Auth0 reflects the change and a verification email is sent (pending transactional email provider, see #52)
- [ ] Send password reset — verify no button appears for social-login accounts; verify 200 from Auth0 for database accounts (email delivery pending #52)
- [x] Verify Edit button toggles forms in/out and Cancel dismisses them
- [x] Run `terraform apply` to push the updated M2M grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)