### PR TITLE
fix: populate DisplayName in authUserState cookie on login

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -173,6 +173,7 @@ func (s *Service) handleGetAuthCallback(w http.ResponseWriter, r *http.Request) 
 		Email:       strings.TrimSpace(claims.Email),
 		GivenName:   strings.TrimSpace(claims.GivenName),
 		FamilyName:  strings.TrimSpace(claims.FamilyName),
+		DisplayName: strings.TrimSpace(claims.DisplayName),
 		UserType:    userType,
 		IsAdmin:     claims.IsAdmin,
 	}, expiresIn)


### PR DESCRIPTION
## Summary

Fixes #72 — display name reverts to old value after logout/login.

- Adds `DisplayName: strings.TrimSpace(claims.DisplayName)` when writing the `authUserState` cookie in the auth callback, so the updated display name (from the Auth0 post-login Action's custom JWT claim) is persisted into the session on every login.

## Root cause

The `authUserState` cookie was recreated on every login without a `DisplayName` field. The middleware would then fall back to `claims.DisplayName` from the JWT rather than the session cookie. After a display name update the cookie was patched correctly mid-session, but the next login overwrote it with an empty value again — causing the middleware to re-read the (potentially stale) JWT claim.

## Test plan

- [ ] Update display name via Edit Profile
- [ ] Verify name appears immediately
- [ ] Log out and log back in
- [ ] Verify the updated display name is still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)