### PR TITLE
fix: replace unregistered dict calls with param in templates

### DIFF
--- a/internal/server/templates/components/need-card.html
+++ b/internal/server/templates/components/need-card.html
@@ -41,7 +41,7 @@
   </div>
 
   <footer class="px-6">
-    <a href="{{route "need.detail" (dict "needID" .ID)}}"
+    <a href="{{route "need.detail" (param "needID" .ID)}}"
       class="inline-flex h-9 w-full items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
       View Details
     </a>

--- a/internal/server/templates/pages/admin-needs.html
+++ b/internal/server/templates/pages/admin-needs.html
@@ -40,11 +40,11 @@
         <tbody class="divide-y divide-border">
           {{range .Needs}}
           <tr>
-            <td class="py-3 pr-4 font-mono text-xs"><a href="{{route "admin.need.review" (dict "needID" .NeedID)}}" class="hover:underline">{{.NeedID}}</a></td>
+            <td class="py-3 pr-4 font-mono text-xs"><a href="{{route "admin.need.review" (param "needID" .NeedID)}}" class="hover:underline">{{.NeedID}}</a></td>
             <td class="py-3 pr-4">{{.Status}}</td>
             <td class="py-3 pr-4">{{.SubmittedAt}}</td>
             <td class="py-3 pr-4">{{.CreatedAt}}</td>
-            <td class="py-3"><a href="{{route "admin.need.review" (dict "needID" .NeedID)}}" class="text-[color:var(--cj-primary)] hover:underline">Open</a></td>
+            <td class="py-3"><a href="{{route "admin.need.review" (param "needID" .NeedID)}}" class="text-[color:var(--cj-primary)] hover:underline">Open</a></td>
           </tr>
           {{end}}
         </tbody>

--- a/internal/server/templates/pages/need-detail.html
+++ b/internal/server/templates/pages/need-detail.html
@@ -144,7 +144,7 @@
             <div class="text-xs font-medium text-muted-foreground">{{.FundingPercent}}% funded</div>
           </div>
 
-          <a href="{{route "need.donate" (dict "needID" .ID)}}"
+          <a href="{{route "need.donate" (param "needID" .ID)}}"
             class="inline-flex h-10 w-full items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
             Donate to this Need
           </a>

--- a/internal/server/templates/pages/need-donate-confirmation.html
+++ b/internal/server/templates/pages/need-donate-confirmation.html
@@ -24,12 +24,12 @@
 
     <div class="mt-6 flex flex-wrap gap-3">
       {{if .ShowRetryCTA}}
-      <a href="{{route "need.donate" (dict "needID" .NeedID)}}"
+      <a href="{{route "need.donate" (param "needID" .NeedID)}}"
         class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
         Try Donation Again
       </a>
       {{end}}
-      <a href="{{route "need.detail" (dict "needID" .NeedID)}}"
+      <a href="{{route "need.detail" (param "needID" .NeedID)}}"
         class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted">
         Back to Need Details
       </a>

--- a/internal/server/templates/pages/need-donate.html
+++ b/internal/server/templates/pages/need-donate.html
@@ -28,7 +28,7 @@
       <h1 class="text-3xl font-semibold text-foreground">Choose your donation amount</h1>
       <p class="mt-2 text-base text-muted-foreground">Secure payment via Stripe. 100% goes to the recipient.</p>
 
-      <form method="post" action="{{route "need.donate" (dict "needID" .NeedID)}}" class="mt-7 space-y-6">
+      <form method="post" action="{{route "need.donate" (param "needID" .NeedID)}}" class="mt-7 space-y-6">
         {{.CSRFField}}
         <div class="grid grid-cols-2 gap-3">
           {{range .PresetAmounts}}

--- a/internal/server/templates/pages/onboarding/need/details.html
+++ b/internal/server/templates/pages/onboarding/need/details.html
@@ -20,7 +20,7 @@
   </div>
 
   <div class="flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
-    <form id="details-form" action="{{route "onboarding.need.details" (dict "needID" .ID)}}" method="post" class="space-y-6 px-6">
+    <form id="details-form" action="{{route "onboarding.need.details" (param "needID" .ID)}}" method="post" class="space-y-6 px-6">
       {{.CSRFField}}
       {{if .PrimaryCategory}}
       <div class="space-y-2">
@@ -60,7 +60,7 @@
   </div>
 
   <div class="mt-6 flex items-center justify-between">
-    <a href="{{route "onboarding.need.categories" (dict "needID" .ID)}}"
+    <a href="{{route "onboarding.need.categories" (param "needID" .ID)}}"
       class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium transition-all hover:bg-accent hover:text-accent-foreground">
       Back
     </a>

--- a/internal/server/templates/pages/onboarding/need/welcome.html
+++ b/internal/server/templates/pages/onboarding/need/welcome.html
@@ -54,7 +54,7 @@
   </div>
 
   <div class="mt-6 flex items-center justify-end">
-    <form method="POST" action="{{route "onboarding.need.welcome" (dict "needID" .Need.ID)}}">
+    <form method="POST" action="{{route "onboarding.need.welcome" (param "needID" .Need.ID)}}">
       {{.CSRFField}}
       <button type="submit"
         class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-all hover:bg-[color:var(--cj-primary)]/90">

--- a/internal/server/templates/pages/profile.html
+++ b/internal/server/templates/pages/profile.html
@@ -156,7 +156,7 @@
             </a>
             {{end}}
             {{if .CanDelete}}
-            <form method="POST" action="{{route "profile.need.delete" (dict "needID" .NeedID)}}" class="mt-3">
+            <form method="POST" action="{{route "profile.need.delete" (param "needID" .NeedID)}}" class="mt-3">
               {{$.CSRFField}}
               <button type="submit"
                 class="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--cj-error)]/40 px-3 text-xs font-medium text-[color:var(--cj-error)] transition-colors hover:bg-[color:var(--cj-error)]/10">
@@ -207,9 +207,9 @@
                 <td class="px-4 py-3 text-sm text-muted-foreground">{{.CreatedAt}}</td>
                 <td class="px-4 py-3 text-sm">
                   <div class="flex items-center gap-3">
-                    <a href="{{route "need.detail" (dict "needID" .NeedID)}}" class="font-medium text-[color:var(--cj-primary)] hover:underline">View need</a>
+                    <a href="{{route "need.detail" (param "needID" .NeedID)}}" class="font-medium text-[color:var(--cj-primary)] hover:underline">View need</a>
                     {{if .IsFinalized}}
-                    <a href="{{route "profile.donation.receipt" (dict "intentID" .IntentID)}}" target="_blank" rel="noopener noreferrer"
+                    <a href="{{route "profile.donation.receipt" (param "intentID" .IntentID)}}" target="_blank" rel="noopener noreferrer"
                       class="font-medium text-[color:var(--cj-primary)] hover:underline">View receipt</a>
                     {{else}}
                       <span class="text-muted-foreground">Receipt pending</span>


### PR DESCRIPTION
## Summary

- `dict` is not a registered template function — all 10 occurrences across 8 template files caused a fatal parse error at startup
- Replaced every `(dict "key" .Value)` with `(param "key" .Value)`, which is the registered helper that returns a `RouteOption` as expected by the `route` template function

## Affected files

- `components/need-card.html`
- `pages/need-donate.html`
- `pages/need-detail.html`
- `pages/need-donate-confirmation.html`
- `pages/profile.html`
- `pages/admin-needs.html`
- `pages/onboarding/need/details.html`
- `pages/onboarding/need/welcome.html`

## Test plan

- [ ] App starts without fatal template parse error
- [ ] Need detail page loads and donate link resolves correctly
- [ ] Donate page form posts to correct URL
- [ ] Donate confirmation back-links resolve correctly
- [ ] Profile page need/donation links resolve correctly
- [ ] Admin needs queue links resolve correctly
- [ ] Onboarding need flow navigates correctly through details and welcome steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)