### PR TITLE
fix: inject display_name claim in Auth0 post-login Action

### DIFF
--- a/terraform/actions/inject_user_roles.js
+++ b/terraform/actions/inject_user_roles.js
@@ -5,4 +5,13 @@ exports.onExecutePostLogin = async (event, api) => {
   api.idToken.setCustomClaim(`${namespace}/roles`, roles);
   api.accessToken.setCustomClaim(`${namespace}/roles`, roles);
 
+  const meta = event.user.user_metadata || {};
+  const displayName =
+    meta.display_name ||
+    meta.given_name ||
+    event.user.given_name ||
+    event.user.nickname ||
+    "";
+
+  api.idToken.setCustomClaim(`${namespace}/display_name`, displayName);
 };


### PR DESCRIPTION
## Summary

Closes #72 (root cause fix)

The post-login Action was only injecting roles into the ID token — the `display_name` claim was never set. This meant `claims.DisplayName` was always empty on login, so the display name reverted to empty after every logout/login regardless of what was stored in `user_metadata`.

Adds `display_name` injection using the fallback chain:
`user_metadata.display_name` → `user_metadata.given_name` → `given_name` → `nickname`

## Deployment

Requires `terraform apply` to push the updated Action to Auth0.

## Test plan

- [ ] `terraform apply` succeeds
- [ ] Log in — confirm the ID token contains `https://christjesus.app/claims/display_name`
- [ ] Update display name via Edit Profile
- [ ] Log out and log back in
- [ ] Confirm updated display name is still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)