### PR TITLE
fix: raise nav z-index to prevent hero from obscuring dropdown menu

### DIFF
--- a/internal/server/templates/components/nav.html
+++ b/internal/server/templates/components/nav.html
@@ -1,5 +1,5 @@
 {{define "component.nav"}}
-<header class="border-b border-[color:var(--border)] bg-[color:var(--cream)]/80 backdrop-blur">
+<header class="relative z-30 border-b border-[color:var(--border)] bg-[color:var(--cream)]/80 backdrop-blur">
   <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 md:px-6">
     <a href="{{route "home"}}" class="flex items-center gap-2">
       <span class="font-display text-2xl font-semibold text-[#0D1B2A]">Christ<span class="text-[color:var(--cj-secondary)]">Jesus</span>.app</span>


### PR DESCRIPTION
## Summary

- Adds `relative z-30` to the `<header>` in `nav.html` so the nav establishes a stacking context above page hero sections

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)