### PR TITLE
feat: smart donation preset amounts when need is close to funded

### DIFF
--- a/internal/server/donate.go
+++ b/internal/server/donate.go
@@ -18,30 +18,45 @@ import (
 
 var donatePresetAmounts = []int{25, 50, 100, 250}
 
-// smartPresetAmounts returns preset donation amounts, replacing the first preset
-// that exceeds the remaining balance with the exact remaining amount when the
-// need is close to fully funded.
-func smartPresetAmounts(amountNeededCents, amountRaisedCents int) []int {
+// smartPresetAmounts returns the filtered preset amounts and an optional
+// remaining-balance CTA amount for the donate form.
+//
+// Presets that would exceed the remaining balance are removed. When any
+// presets are removed (i.e. remaining < the largest preset), the exact
+// remaining dollar amount is returned as remainingPreset so the template
+// can render it as a full-width CTA below the grid. If remaining exactly
+// matches a standard preset no CTA is needed. If the need is fully funded
+// or remaining >= the largest preset, static presets are returned unchanged
+// with remainingPreset=0.
+func smartPresetAmounts(amountNeededCents, amountRaisedCents int) (presets []int, remainingPreset int) {
 	remainingCents := amountNeededCents - amountRaisedCents
 	if remainingCents <= 0 {
-		return donatePresetAmounts
+		return donatePresetAmounts, 0
 	}
 
 	remainingDollars := remainingCents / 100
-	for i, preset := range donatePresetAmounts {
-		if remainingDollars == preset {
-			// remaining already matches this preset — no substitution needed
-			break
-		}
-		if remainingDollars < preset {
-			result := make([]int, len(donatePresetAmounts))
-			copy(result, donatePresetAmounts)
-			result[i] = remainingDollars
-			return result
+	if remainingDollars == 0 {
+		return donatePresetAmounts, 0
+	}
+
+	var filtered []int
+	for _, preset := range donatePresetAmounts {
+		if preset <= remainingDollars {
+			filtered = append(filtered, preset)
 		}
 	}
 
-	return donatePresetAmounts
+	// All presets fit within the remaining balance — no CTA needed.
+	if len(filtered) == len(donatePresetAmounts) {
+		return donatePresetAmounts, 0
+	}
+
+	// Remaining exactly matches the highest kept preset — already represented.
+	if len(filtered) > 0 && filtered[len(filtered)-1] == remainingDollars {
+		return filtered, 0
+	}
+
+	return filtered, remainingDollars
 }
 
 func (s *Service) handleGetNeedDonate(w http.ResponseWriter, r *http.Request) {
@@ -388,7 +403,7 @@ func (s *Service) buildNeedDonatePageData(ctx context.Context, needID string, da
 	data.AmountNeededCents = need.AmountNeededCents
 	data.AmountRaisedCents = need.AmountRaisedCents
 	if len(data.PresetAmounts) == 0 {
-		data.PresetAmounts = smartPresetAmounts(need.AmountNeededCents, need.AmountRaisedCents)
+		data.PresetAmounts, data.RemainingPreset = smartPresetAmounts(need.AmountNeededCents, need.AmountRaisedCents)
 	}
 
 	return data, nil

--- a/internal/server/donate_test.go
+++ b/internal/server/donate_test.go
@@ -9,80 +9,95 @@ func TestSmartPresetAmounts(t *testing.T) {
 		name              string
 		amountNeededCents int
 		amountRaisedCents int
-		want              []int
+		wantPresets       []int
+		wantRemaining     int
 	}{
 		{
-			name:              "fully funded returns static presets",
+			name:              "fully funded returns static presets, no CTA",
 			amountNeededCents: 10000,
 			amountRaisedCents: 10000,
-			want:              []int{25, 50, 100, 250},
+			wantPresets:       []int{25, 50, 100, 250},
+			wantRemaining:     0,
 		},
 		{
-			name:              "overfunded returns static presets",
+			name:              "overfunded returns static presets, no CTA",
 			amountNeededCents: 10000,
 			amountRaisedCents: 12000,
-			want:              []int{25, 50, 100, 250},
+			wantPresets:       []int{25, 50, 100, 250},
+			wantRemaining:     0,
 		},
 		{
-			name:              "remaining above largest preset returns static presets",
+			name:              "remaining above largest preset returns static presets, no CTA",
 			amountNeededCents: 100000,
 			amountRaisedCents: 0,
-			want:              []int{25, 50, 100, 250},
+			wantPresets:       []int{25, 50, 100, 250},
+			wantRemaining:     0,
 		},
 		{
-			// remaining=$7 — replaces first slot
-			name:              "remaining below first preset replaces first slot",
+			// remaining=$7 — below all presets; grid empty, CTA only
+			name:              "remaining below first preset shows no grid presets",
 			amountNeededCents: 10000,
 			amountRaisedCents: 9300,
-			want:              []int{7, 50, 100, 250},
+			wantPresets:       nil,
+			wantRemaining:     7,
 		},
 		{
-			// remaining=$35 — between $25 and $50, replaces second slot
-			name:              "remaining between first and second preset replaces second slot",
+			// remaining=$35 — only $25 fits; $50/$100/$250 removed, CTA=$35
+			name:              "remaining between first and second preset filters overages",
 			amountNeededCents: 10000,
 			amountRaisedCents: 6500,
-			want:              []int{25, 35, 100, 250},
+			wantPresets:       []int{25},
+			wantRemaining:     35,
 		},
 		{
-			// remaining=$75 — between $50 and $100, replaces third slot
-			name:              "remaining between second and third preset replaces third slot",
+			// remaining=$75 — $25 and $50 fit; $100/$250 removed, CTA=$75
+			name:              "remaining between second and third preset filters overages",
 			amountNeededCents: 10000,
 			amountRaisedCents: 2500,
-			want:              []int{25, 50, 75, 250},
+			wantPresets:       []int{25, 50},
+			wantRemaining:     75,
 		},
 		{
-			// remaining=$150 — between $100 and $250, replaces fourth slot
-			name:              "remaining between third and fourth preset replaces fourth slot",
+			// remaining=$150 — $25/$50/$100 fit; $250 removed, CTA=$150
+			name:              "remaining between third and fourth preset filters overages",
 			amountNeededCents: 20000,
 			amountRaisedCents: 5000,
-			want:              []int{25, 50, 100, 150},
+			wantPresets:       []int{25, 50, 100},
+			wantRemaining:     150,
 		},
 		{
-			// remaining=$25 — exactly equals first preset, no substitution needed
-			name:              "remaining exactly equal to a preset returns static presets",
+			// remaining=$25 exactly — matches preset, no CTA needed
+			name:              "remaining exactly equal to a preset returns that preset, no CTA",
 			amountNeededCents: 10000,
 			amountRaisedCents: 7500,
-			want:              []int{25, 50, 100, 250},
+			wantPresets:       []int{25},
+			wantRemaining:     0,
 		},
 		{
-			// remaining=$50 — exactly equals second preset, no substitution needed
-			name:              "remaining exactly equal to second preset returns static presets",
+			// remaining=$50 exactly — matches preset, no CTA needed
+			name:              "remaining exactly equal to second preset, no CTA",
 			amountNeededCents: 10000,
 			amountRaisedCents: 5000,
-			want:              []int{25, 50, 100, 250},
+			wantPresets:       []int{25, 50},
+			wantRemaining:     0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := smartPresetAmounts(tt.amountNeededCents, tt.amountRaisedCents)
-			if len(got) != len(tt.want) {
-				t.Fatalf("len = %d, want %d", len(got), len(tt.want))
+			gotPresets, gotRemaining := smartPresetAmounts(tt.amountNeededCents, tt.amountRaisedCents)
+
+			if len(gotPresets) != len(tt.wantPresets) {
+				t.Fatalf("presets len = %d, want %d (got %v, want %v)", len(gotPresets), len(tt.wantPresets), gotPresets, tt.wantPresets)
 			}
-			for i := range tt.want {
-				if got[i] != tt.want[i] {
-					t.Errorf("presets[%d] = %d, want %d", i, got[i], tt.want[i])
+			for i := range tt.wantPresets {
+				if gotPresets[i] != tt.wantPresets[i] {
+					t.Errorf("presets[%d] = %d, want %d", i, gotPresets[i], tt.wantPresets[i])
 				}
+			}
+
+			if gotRemaining != tt.wantRemaining {
+				t.Errorf("remainingPreset = %d, want %d", gotRemaining, tt.wantRemaining)
 			}
 		})
 	}

--- a/internal/server/templates/pages/need-donate.html
+++ b/internal/server/templates/pages/need-donate.html
@@ -30,6 +30,7 @@
 
       <form method="post" action="{{route "need.donate" (param "needID" .NeedID)}}" class="mt-7 space-y-6">
         {{.CSRFField}}
+        {{if .PresetAmounts}}
         <div class="grid grid-cols-2 gap-3">
           {{range .PresetAmounts}}
           <label class="block cursor-pointer">
@@ -39,6 +40,17 @@
           </label>
           {{end}}
         </div>
+        {{end}}
+
+        {{if .RemainingPreset}}
+        <label class="block cursor-pointer">
+          <input type="radio" name="preset_amount" value="{{.RemainingPreset}}" class="peer sr-only" {{if eq .SelectedPreset .RemainingPreset}}checked{{end}} />
+          <span
+            class="inline-flex h-14 w-full items-center justify-center rounded-md border-2 border-[color:var(--cj-primary)] bg-[color:var(--cj-primary)]/10 px-4 text-lg font-bold text-[color:var(--cj-primary)] transition-colors peer-checked:bg-[color:var(--cj-primary)] peer-checked:text-white">
+            Fund the remaining ${{.RemainingPreset}}
+          </span>
+        </label>
+        {{end}}
 
         <div>
           <label for="custom_amount" class="block text-sm font-semibold text-foreground">Custom amount</label>

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -150,7 +150,8 @@ type NeedDonatePageData struct {
 	PrivateMessage    string
 	IsAnonymous       bool
 	Error             string
-	PresetAmounts     []int
+	PresetAmounts   []int
+	RemainingPreset int // non-zero when remaining < largest preset; rendered as full-width CTA
 }
 
 type NeedDonateConfirmationPageData struct {


### PR DESCRIPTION
## Summary

- Filters out donation presets that would exceed the remaining balance (no more overages)
- Adds the exact remaining amount as a **full-width, gold CTA button** below the grid — visually distinct from the smaller presets to drive completion
- When remaining exactly matches a standard preset, no duplicate CTA is shown
- When no standard presets fit (very small remaining), only the CTA renders
- When remaining ≥ $250, static presets unchanged with no CTA

### Examples
| Remaining | Grid presets | CTA |
|---|---|---|
| $500+ | $25 · $50 · $100 · $250 | none |
| $150 | $25 · $50 · $100 | "Fund the remaining $150" |
| $73 | $25 · $50 | "Fund the remaining $73" |
| $7 | _(none)_ | "Fund the remaining $7" |
| $50 exactly | $25 · $50 | none |

## Test plan

- [ ] `go test ./internal/server/ -run TestSmartPresetAmounts -v` — 9 table-driven cases covering all branches
- [ ] Manual: open a need with ~$73 remaining — verify $100/$250 are gone and the gold CTA appears
- [ ] Manual: open a need with $500+ remaining — verify static presets unchanged, no CTA

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)