### PR TITLE
feat: show similar needs on donation confirmation

### DIFF
--- a/internal/server/donate.go
+++ b/internal/server/donate.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"christjesus/internal/store"
 	"christjesus/internal/utils"
 	"christjesus/pkg/types"
 
@@ -289,7 +290,7 @@ func (s *Service) handleGetNeedDonateConfirmation(w http.ResponseWriter, r *http
 		return
 	}
 
-	need, ownerName, primaryCategory, err := s.loadNeedDonateSummary(ctx, needID)
+	need, ownerName, primaryCategory, primaryCategoryID, err := s.loadNeedDonateSummary(ctx, needID)
 	if err != nil {
 		s.logger.WithError(err).WithField("need_id", needID).Error("failed to build donate confirmation page data")
 		s.internalServerError(w)
@@ -312,6 +313,29 @@ func (s *Service) handleGetNeedDonateConfirmation(w http.ResponseWriter, r *http
 		ShowRetryCTA:       intent.PaymentStatus == types.DonationPaymentStatusFailed || intent.PaymentStatus == types.DonationPaymentStatusCanceled,
 		ShowReceiptDetails: intent.PaymentStatus == types.DonationPaymentStatusFinalized,
 		DonationDate:       donationConfirmationDate(intent),
+	}
+
+	if primaryCategoryID != "" {
+		rows, err := s.needsRepo.BrowseNeedsPage(ctx, store.BrowseNeedsFilter{
+			CategoryIDs: []string{primaryCategoryID},
+			PageSize:    4,
+		})
+		if err != nil {
+			s.logger.WithError(err).WithField("need_id", needID).Warn("failed to fetch similar needs for donation confirmation")
+		} else {
+			candidateNeeds := make([]*types.Need, 0, len(rows))
+			for _, row := range rows {
+				if row.ID == needID {
+					continue
+				}
+				n := row.Need
+				candidateNeeds = append(candidateNeeds, &n)
+				if len(candidateNeeds) == 3 {
+					break
+				}
+			}
+			data.SimilarNeeds = s.buildNeedCards(ctx, candidateNeeds, "donation-confirmation-similar")
+		}
 	}
 
 	if err := s.renderTemplate(w, r, "page.need-donate-confirmation", data); err != nil {
@@ -386,7 +410,7 @@ func donationConfirmationDate(intent *types.DonationIntent) string {
 }
 
 func (s *Service) buildNeedDonatePageData(ctx context.Context, needID string, data *types.NeedDonatePageData) (*types.NeedDonatePageData, error) {
-	need, ownerName, primaryCategory, err := s.loadNeedDonateSummary(ctx, needID)
+	need, ownerName, primaryCategory, _, err := s.loadNeedDonateSummary(ctx, needID)
 	if err != nil {
 		return nil, err
 	}
@@ -409,13 +433,13 @@ func (s *Service) buildNeedDonatePageData(ctx context.Context, needID string, da
 	return data, nil
 }
 
-func (s *Service) loadNeedDonateSummary(ctx context.Context, needID string) (*types.Need, string, string, error) {
+func (s *Service) loadNeedDonateSummary(ctx context.Context, needID string) (*types.Need, string, string, string, error) {
 	need, err := s.needsRepo.Need(ctx, needID)
 	if err != nil {
-		return nil, "", "", err
+		return nil, "", "", "", err
 	}
 	if need.DeletedAt != nil {
-		return nil, "", "", types.ErrNeedNotFound
+		return nil, "", "", "", types.ErrNeedNotFound
 	}
 
 	ownerName := "Anonymous"
@@ -427,18 +451,20 @@ func (s *Service) loadNeedDonateSummary(ctx context.Context, needID string) (*ty
 	}
 
 	primaryCategoryName := "General Need"
+	primaryCategoryID := ""
 	assignments, err := s.needCategoryAssignmentsRepo.GetAssignmentsByNeedID(ctx, needID)
 	if err != nil {
-		return nil, "", "", err
+		return nil, "", "", "", err
 	}
 
 	for _, assignment := range assignments {
 		if !assignment.IsPrimary {
 			continue
 		}
+		primaryCategoryID = assignment.CategoryID
 		category, err := s.categoryRepo.CategoryByID(ctx, assignment.CategoryID)
 		if err != nil {
-			return nil, "", "", err
+			return nil, "", "", "", err
 		}
 		if category != nil && strings.TrimSpace(category.Name) != "" {
 			primaryCategoryName = category.Name
@@ -446,7 +472,7 @@ func (s *Service) loadNeedDonateSummary(ctx context.Context, needID string) (*ty
 		break
 	}
 
-	return need, ownerName, primaryCategoryName, nil
+	return need, ownerName, primaryCategoryName, primaryCategoryID, nil
 }
 
 func parseDonationAmountCents(raw string) (int, error) {

--- a/internal/server/donate.go
+++ b/internal/server/donate.go
@@ -318,6 +318,7 @@ func (s *Service) handleGetNeedDonateConfirmation(w http.ResponseWriter, r *http
 	if primaryCategoryID != "" {
 		rows, err := s.needsRepo.BrowseNeedsPage(ctx, store.BrowseNeedsFilter{
 			CategoryIDs: []string{primaryCategoryID},
+			FundingMax:  100,
 			PageSize:    4,
 		})
 		if err != nil {

--- a/internal/server/templates/pages/need-donate-confirmation.html
+++ b/internal/server/templates/pages/need-donate-confirmation.html
@@ -41,5 +41,21 @@
   </div>
 </div>
 
+{{if .SimilarNeeds}}
+<div class="mx-auto w-full max-w-3xl px-4 pb-10 md:px-6">
+  <section class="space-y-4">
+    <div>
+      <h2 class="text-lg font-semibold text-foreground">Needs like this</h2>
+      <p class="text-sm text-muted-foreground">Other active requests in {{.PrimaryCategory}}</p>
+    </div>
+    <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+      {{range .SimilarNeeds}}
+      {{template "component.need.card" .}}
+      {{end}}
+    </div>
+  </section>
+</div>
+{{end}}
+
 {{template "footer" .}}
 {{end}}

--- a/internal/server/templates/pages/need-donate-confirmation.html
+++ b/internal/server/templates/pages/need-donate-confirmation.html
@@ -1,61 +1,63 @@
 {{define "page.need-donate-confirmation"}}
 {{template "header" .}}
 
-<div class="mx-auto w-full max-w-3xl px-4 py-10 md:px-6">
-  <div class="rounded-xl border bg-card p-8 shadow-sm">
-    <p class="text-sm font-semibold uppercase tracking-wide text-[color:var(--cj-accent)]">{{.StatusLabel}}</p>
-    <h1 class="mt-2 text-3xl font-semibold text-foreground">{{.StatusTitle}}</h1>
-    <p class="mt-3 text-muted-foreground">{{.StatusDescription}}</p>
-    <p class="mt-2 text-sm text-muted-foreground">{{.StatusGuidance}}</p>
+<div class="mx-auto w-full {{if .SimilarNeeds}}max-w-6xl{{else}}max-w-3xl{{end}} px-4 py-10 md:px-6">
+  <div class="{{if .SimilarNeeds}}grid gap-6 lg:grid-cols-[2fr_3fr]{{end}}">
 
-    <div class="mt-6 space-y-3 rounded-lg border border-border bg-muted/30 p-4 text-sm">
-      <p class="text-foreground"><span class="font-semibold">Status:</span> {{.StatusLabel}}</p>
-      <p class="text-foreground"><span class="font-semibold">Donation Reference ID:</span> {{.IntentID}}</p>
-      <p class="text-foreground"><span class="font-semibold">Amount:</span> ${{div .AmountCents 100}}</p>
-      <p class="text-foreground"><span class="font-semibold">Visibility:</span> {{if .IsAnonymous}}Anonymous
-        {{else}}Public{{end}}
-      </p>
-      <p class="text-foreground"><span class="font-semibold">Category:</span> {{.PrimaryCategory}}</p>
-      {{if .ShowReceiptDetails}}
-      <p class="text-foreground"><span class="font-semibold">Donation Date:</span> {{.DonationDate}}</p>
-      <p class="text-foreground"><span class="font-semibold">Receipt Status:</span> Ready</p>
-      {{end}}
+    <div class="rounded-xl border bg-card p-8 shadow-sm">
+      <p class="text-sm font-semibold uppercase tracking-wide text-[color:var(--cj-accent)]">{{.StatusLabel}}</p>
+      <h1 class="mt-2 text-3xl font-semibold text-foreground">{{.StatusTitle}}</h1>
+      <p class="mt-3 text-muted-foreground">{{.StatusDescription}}</p>
+      <p class="mt-2 text-sm text-muted-foreground">{{.StatusGuidance}}</p>
+
+      <div class="mt-6 space-y-3 rounded-lg border border-border bg-muted/30 p-4 text-sm">
+        <p class="text-foreground"><span class="font-semibold">Status:</span> {{.StatusLabel}}</p>
+        <p class="text-foreground"><span class="font-semibold">Donation Reference ID:</span> {{.IntentID}}</p>
+        <p class="text-foreground"><span class="font-semibold">Amount:</span> ${{div .AmountCents 100}}</p>
+        <p class="text-foreground"><span class="font-semibold">Visibility:</span> {{if .IsAnonymous}}Anonymous
+          {{else}}Public{{end}}
+        </p>
+        <p class="text-foreground"><span class="font-semibold">Category:</span> {{.PrimaryCategory}}</p>
+        {{if .ShowReceiptDetails}}
+        <p class="text-foreground"><span class="font-semibold">Donation Date:</span> {{.DonationDate}}</p>
+        <p class="text-foreground"><span class="font-semibold">Receipt Status:</span> Ready</p>
+        {{end}}
+      </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        {{if .ShowRetryCTA}}
+        <a href="{{route "need.donate" (param "needID" .NeedID)}}"
+          class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
+          Try Donation Again
+        </a>
+        {{end}}
+        <a href="{{route "need.detail" (param "needID" .NeedID)}}"
+          class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted">
+          Back to Need Details
+        </a>
+        <a href="{{route "browse"}}"
+          class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted">
+          Browse More Needs
+        </a>
+      </div>
     </div>
 
-    <div class="mt-6 flex flex-wrap gap-3">
-      {{if .ShowRetryCTA}}
-      <a href="{{route "need.donate" (param "needID" .NeedID)}}"
-        class="inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--cj-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[color:var(--cj-primary)]/90">
-        Try Donation Again
-      </a>
-      {{end}}
-      <a href="{{route "need.detail" (param "needID" .NeedID)}}"
-        class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted">
-        Back to Need Details
-      </a>
-      <a href="{{route "browse"}}"
-        class="inline-flex h-9 items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted">
-        Browse More Needs
-      </a>
-    </div>
+    {{if .SimilarNeeds}}
+    <section class="space-y-4">
+      <div>
+        <h2 class="text-lg font-semibold text-foreground">Needs like this</h2>
+        <p class="text-sm text-muted-foreground">Other active requests in {{.PrimaryCategory}}</p>
+      </div>
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+        {{range .SimilarNeeds}}
+        {{template "component.need.card" .}}
+        {{end}}
+      </div>
+    </section>
+    {{end}}
+
   </div>
 </div>
-
-{{if .SimilarNeeds}}
-<div class="mx-auto w-full max-w-3xl px-4 pb-10 md:px-6">
-  <section class="space-y-4">
-    <div>
-      <h2 class="text-lg font-semibold text-foreground">Needs like this</h2>
-      <p class="text-sm text-muted-foreground">Other active requests in {{.PrimaryCategory}}</p>
-    </div>
-    <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-      {{range .SimilarNeeds}}
-      {{template "component.need.card" .}}
-      {{end}}
-    </div>
-  </section>
-</div>
-{{end}}
 
 {{template "footer" .}}
 {{end}}

--- a/pkg/types/page_data.go
+++ b/pkg/types/page_data.go
@@ -173,6 +173,7 @@ type NeedDonateConfirmationPageData struct {
 	ShowRetryCTA       bool
 	ShowReceiptDetails bool
 	DonationDate       string
+	SimilarNeeds       []*BrowseNeedCard
 }
 
 type LoginPageData struct {


### PR DESCRIPTION
## Summary
- After a successful donation, display up to 3 active needs from the same primary category below the confirmation summary
- Section header reads "Needs like this" with subtitle "Other active requests in {category name}"
- Section is omitted entirely when no similar needs exist (e.g. no other active needs in the category)
- Existing "Browse More Needs" CTA is preserved

## Implementation notes
- Extended `loadNeedDonateSummary` to return the primary category ID alongside the name
- Uses existing `BrowseNeedsPage` with a category filter (fetches 4, excludes the donated-to need, keeps up to 3)
- Reuses the existing `component.need.card` partial and `buildNeedCards` helper
- Similar needs fetch is best-effort: a failure logs a warning but does not break the confirmation page

## Test plan
- [ ] Donate to a need that has other active needs in the same category — confirm "Needs like this" section appears with up to 3 cards
- [ ] Donate to a need with no other active needs in its category — confirm section is absent
- [ ] Verify the existing confirmation details (status, amount, receipt link) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)